### PR TITLE
Configurable session cookie flags

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -17,6 +17,11 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 ACCESS_TOKEN_MINUTES=10080
 WHATSAPP_LOG_LEVEL=silent
 
+# Session cookie flags. Behind HTTPS set COOKIE_SECURE=true. If the frontend and
+# API are served from different sites, set COOKIE_SAMESITE=none (needs COOKIE_SECURE=true).
+COOKIE_SECURE=false
+COOKIE_SAMESITE=lax
+
 # Host ports. Change any that clash with other local services.
 # If you change API_PORT, also update NEXT_PUBLIC_API_URL above (or use `make up`).
 API_PORT=8000

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ ENCRYPTION_KEY=change-this-other-long-random-key
 # Frontend origin allowed by CORS
 FRONTEND_URL=http://localhost:3000
 
+# Session cookie flags. Behind HTTPS set COOKIE_SECURE=true. If the frontend and
+# API are on different sites, set COOKIE_SAMESITE=none (which requires
+# COOKIE_SECURE=true).
+COOKIE_SECURE=false
+COOKIE_SAMESITE=lax
+
 # Public backend URL used by Next.js
 NEXT_PUBLIC_API_URL=http://localhost:8000
 

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -15,6 +15,11 @@ class Settings(BaseSettings):
     encryption_key: str = "dev-local-change-this-key-too"
     frontend_url: str = "http://localhost:3000"
     access_token_minutes: int = 60 * 24 * 7
+    # Session cookie flags. Defaults suit local HTTP; set cookie_secure=true (and
+    # cookie_samesite=none when the frontend and API are on different sites)
+    # behind HTTPS in production.
+    cookie_secure: bool = False
+    cookie_samesite: str = "lax"
     storage_dir: Path = APP_DIR / "storage"
     backend_url: str = "http://localhost:8000"
     whatsapp_bridge_url: str = "http://localhost:3101"

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -20,8 +20,8 @@ def _set_session_cookie(response: Response, user: User) -> None:
         key="access_token",
         value=create_access_token(str(user.id)),
         httponly=True,
-        secure=False,
-        samesite="lax",
+        secure=settings.cookie_secure,
+        samesite=settings.cookie_samesite,
         max_age=settings.access_token_minutes * 60,
         path="/",
     )

--- a/apps/api/app/routers/portal.py
+++ b/apps/api/app/routers/portal.py
@@ -96,13 +96,14 @@ def portal_login(slug: str, payload: PortalLoginRequest, response: Response, db:
         or not verify_password(payload.password, client.portal_password_hash)
     ):
         raise HTTPException(status_code=401, detail="Incorrect email or password")
+    settings = get_settings()
     response.set_cookie(
         key="portal_access_token",
         value=create_portal_token(str(client.id), client.portal_slug),
         httponly=True,
-        secure=False,
-        samesite="lax",
-        max_age=get_settings().access_token_minutes * 60,
+        secure=settings.cookie_secure,
+        samesite=settings.cookie_samesite,
+        max_age=settings.access_token_minutes * 60,
         path="/",
     )
     agency = db.get(Agency, client.agency_id)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -69,10 +69,36 @@ hand, copy `.env.docker.example` to `.env.docker` and replace every `CHANGE_*`.
 | `WHATSAPP_BRIDGE_TOKEN` | Backend + bridge | Authenticates the private backend↔bridge calls. |
 | `FRONTEND_URL` | Backend | Origin allowed by CORS; usually `http://localhost:3000`. |
 | `NEXT_PUBLIC_API_URL` | Browser / frontend build | Address the browser uses to reach the API. |
+| `COOKIE_SECURE` | Backend | `true` behind HTTPS so the session cookie is only sent over TLS. |
+| `COOKIE_SAMESITE` | Backend | `lax` (default). Use `none` when the frontend and API are on different sites (requires `COOKIE_SECURE=true`). |
 | `ACCESS_TOKEN_MINUTES` | Backend | Session lifetime. |
 | `WHATSAPP_LOG_LEVEL` | Bridge | Log level; `silent` avoids exposing sensitive data. |
 | `API_PORT`, `WEB_PORT`, `DB_PORT` | Host | Host ports (defaults `8000` / `3000` / `5432`). |
 | `BIND_HOST` | Host | Bind address: `127.0.0.1` (local) or `0.0.0.0` (expose on a server). |
+
+## Public / HTTPS deployment
+
+For a server reachable from the internet (not just `localhost`):
+
+1. **Terminate TLS** with a reverse proxy (Caddy, nginx or Traefik) in front of
+   the stack. OpenLivery does not ship one.
+2. **Recommended topology:** serve the frontend and the API under the **same
+   site** — e.g. `app.example.com` (web) and `api.example.com` (API), or one
+   domain with the API behind a `/api` path. Same registrable domain keeps the
+   session cookie working with `COOKIE_SAMESITE=lax`.
+3. Set, before starting:
+   - `FRONTEND_URL=https://app.example.com`
+   - `NEXT_PUBLIC_API_URL=https://api.example.com` (baked at build — rebuild the
+     web image after changing it)
+   - `COOKIE_SECURE=true`
+   - `BIND_HOST=0.0.0.0` if the proxy runs on the same host and connects over the
+     published ports (or keep `127.0.0.1` and proxy to the container network).
+4. If the frontend and API end up on **different registrable domains**, also set
+   `COOKIE_SAMESITE=none` (which requires `COOKIE_SECURE=true`); otherwise the
+   browser will not send the session cookie and login will fail.
+
+Each deployment is a **single agency** (the first registered user is its admin).
+Provider keys are per-agency and brought by the deployer.
 
 ## Day-to-day operation
 


### PR DESCRIPTION
The session cookie was hardcoded `secure=False; samesite=lax`, which isn't production-safe over HTTPS or when the frontend and API are on different sites.

- Adds `COOKIE_SECURE` / `COOKIE_SAMESITE` settings (defaults `false` / `lax` for local HTTP), used by both the agency and portal cookies.
- Behind HTTPS set `COOKIE_SECURE=true`; for a cross-site frontend/API set `COOKIE_SAMESITE=none` (which requires Secure).
- Documents the public/HTTPS deployment steps and adds the vars to the env examples.

Backend **17/17 pytest**; verified live that the default cookie is `HttpOnly; SameSite=lax` and gains `Secure` when enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)