### PR TITLE
One-command HTTPS deploy (bundled Caddy)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -22,6 +22,11 @@ WHATSAPP_LOG_LEVEL=silent
 COOKIE_SECURE=false
 COOKIE_SAMESITE=lax
 
+# Public HTTPS deploy (only for `make deploy`). Set your domain, point its DNS at
+# this server and open ports 80/443. Caddy handles TLS and FRONTEND_URL /
+# NEXT_PUBLIC_API_URL / COOKIE_SECURE automatically for this domain.
+# DOMAIN=agency.example.com
+
 # Host ports. Change any that clash with other local services.
 # If you change API_PORT, also update NEXT_PUBLIC_API_URL above (or use `make up`).
 API_PORT=8000

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export API_PORT WEB_PORT DB_PORT BIND_HOST NEXT_PUBLIC_API_URL
 COMPOSE := docker compose --env-file .env.docker
 
 .DEFAULT_GOAL := help
-.PHONY: help env up down stop start restart build logs ps migrate test shell-api shell-db destroy
+.PHONY: help env up deploy down stop start restart build logs ps migrate test shell-api shell-db destroy
 
 help: ## Show available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-11s\033[0m %s\n", $$1, $$2}'
@@ -30,6 +30,12 @@ up: env ## Build and start the whole stack (detached)
 	@echo ""
 	@echo "  App:  http://localhost:$(WEB_PORT)"
 	@echo "  API:  http://localhost:$(API_PORT)/docs"
+
+deploy: env ## Build and start with the Caddy HTTPS reverse proxy (set DOMAIN in .env.docker)
+	@grep -q '^DOMAIN=..*' .env.docker || { echo "Set DOMAIN=your.domain in .env.docker first."; exit 1; }
+	$(COMPOSE) -f docker-compose.yml -f docker-compose.prod.yml up --build -d
+	@echo ""
+	@echo "  Serving https://$$(grep '^DOMAIN=' .env.docker | cut -d= -f2) once DNS points here and ports 80/443 are open."
 
 down: ## Stop and remove containers (keeps data volumes)
 	$(COMPOSE) down

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ make up                            # build, start, migrate
 Then open **http://localhost:3000** (API docs at **http://localhost:8000/docs**).
 Ports clashing? `API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up`.
 
+**Deploy to a public server** with automatic HTTPS: point a domain at the host,
+set `DOMAIN=your.domain` in `.env.docker` and run `make deploy` (a bundled Caddy
+reverse proxy handles TLS and routing).
+
 Full setup, environment variables, backups, non-Docker install and WhatsApp
 linking are in **[docs/self-hosting.md](docs/self-hosting.md)**.
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,40 @@
+# Production overlay: adds a Caddy reverse proxy with automatic HTTPS and points
+# the app at the public domain. Use with the base file:
+#   docker compose --env-file .env.docker -f docker-compose.yml -f docker-compose.prod.yml up --build -d
+# or simply `make deploy`. Requires DOMAIN set in .env.docker, DNS pointing at
+# this host, and ports 80/443 open. Everything is served from a single domain,
+# so the frontend and API share one origin and the session cookie just works.
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: openlivery_caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN}
+    volumes:
+      - ./docker/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - web
+      - api
+
+  api:
+    environment:
+      FRONTEND_URL: https://${DOMAIN}
+      COOKIE_SECURE: "true"
+
+  web:
+    build:
+      args:
+        NEXT_PUBLIC_API_URL: https://${DOMAIN}
+    environment:
+      NEXT_PUBLIC_API_URL: https://${DOMAIN}
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,10 @@
+# Public entry point. Caddy terminates HTTPS (automatic certificates) and routes
+# API traffic to the backend and everything else to the frontend, on one domain.
+{$DOMAIN} {
+	handle /api/* {
+		reverse_proxy api:8000
+	}
+	handle {
+		reverse_proxy web:3000
+	}
+}

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -78,24 +78,36 @@ hand, copy `.env.docker.example` to `.env.docker` and replace every `CHANGE_*`.
 
 ## Public / HTTPS deployment
 
-For a server reachable from the internet (not just `localhost`):
+For a server reachable from the internet, the stack includes an optional **Caddy**
+reverse proxy that gets and renews HTTPS certificates automatically and serves the
+whole app from a single domain (frontend + API share one origin, so the session
+cookie just works).
 
-1. **Terminate TLS** with a reverse proxy (Caddy, nginx or Traefik) in front of
-   the stack. OpenLivery does not ship one.
-2. **Recommended topology:** serve the frontend and the API under the **same
-   site** — e.g. `app.example.com` (web) and `api.example.com` (API), or one
-   domain with the API behind a `/api` path. Same registrable domain keeps the
-   session cookie working with `COOKIE_SAMESITE=lax`.
-3. Set, before starting:
-   - `FRONTEND_URL=https://app.example.com`
-   - `NEXT_PUBLIC_API_URL=https://api.example.com` (baked at build — rebuild the
-     web image after changing it)
-   - `COOKIE_SECURE=true`
-   - `BIND_HOST=0.0.0.0` if the proxy runs on the same host and connects over the
-     published ports (or keep `127.0.0.1` and proxy to the container network).
-4. If the frontend and API end up on **different registrable domains**, also set
-   `COOKIE_SAMESITE=none` (which requires `COOKIE_SECURE=true`); otherwise the
-   browser will not send the session cookie and login will fail.
+1. On a host with Docker, point your domain's DNS (an `A` record) at the server's
+   IP and open ports **80** and **443**.
+2. Set the domain in `.env.docker`:
+
+   ```bash
+   DOMAIN=agency.example.com
+   ```
+
+3. Deploy:
+
+   ```bash
+   make deploy
+   ```
+
+`make deploy` starts the base stack plus Caddy using `docker-compose.prod.yml`.
+Caddy issues the TLS certificate on first request and routes `/api/*` to the
+backend and everything else to the frontend. `FRONTEND_URL`, `NEXT_PUBLIC_API_URL`
+and `COOKIE_SECURE=true` are set for the domain automatically, so there is nothing
+else to configure. Keep `BIND_HOST=127.0.0.1` (the default) so only Caddy is
+exposed publicly.
+
+Under the hood this is `docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d`;
+run it directly if you prefer. To use your own reverse proxy instead, skip the
+prod overlay and set `FRONTEND_URL`, `NEXT_PUBLIC_API_URL` and `COOKIE_SECURE`
+yourself.
 
 Each deployment is a **single agency** (the first registered user is its admin).
 Provider keys are per-agency and brought by the deployer.


### PR DESCRIPTION
Makes a public deployment plug-and-play.

- `make deploy` runs the base stack + `docker-compose.prod.yml`, which adds a **Caddy** reverse proxy with **automatic HTTPS** (Let's Encrypt) serving the whole app from a single `DOMAIN` — frontend and API share one origin, so the session cookie works with no extra config.
- The overlay sets `FRONTEND_URL`, `NEXT_PUBLIC_API_URL` (build arg) and `COOKIE_SECURE=true` from `DOMAIN` automatically. The deployer only sets `DOMAIN`, points DNS and opens 80/443.
- Adds `docker/Caddyfile`, `docker-compose.prod.yml`, the `deploy` make target, the `DOMAIN` env example and docs.

Validated the merged compose config; the base local `make up` flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)