### PR TITLE
Expand the self-hosting guide

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,44 +1,69 @@
 # Self-hosting OpenLivery
 
-Everything you need to run OpenLivery in production or locally. For a feature
-overview see the [README](../README.md).
+Run and operate your own OpenLivery instance. For a feature overview see the
+[README](../README.md).
 
-OpenLivery is four services: PostgreSQL, the FastAPI backend, the Next.js
-frontend and the WhatsApp bridge (Baileys). Docker Compose runs all four; a
-`Makefile` wraps the common commands.
+OpenLivery is four services orchestrated by Docker Compose, with a `Makefile`
+wrapping the common commands:
+
+| Service | Image | Role |
+| --- | --- | --- |
+| `db` | PostgreSQL | All data (encrypted secrets at rest). |
+| `api` | FastAPI | REST API, models, AI/knowledge/provider services. |
+| `web` | Next.js | Agency dashboard, client portal, playground, widget. |
+| `whatsapp` | Node.js + Baileys | WhatsApp Web bridge (internal only). |
+
+One instance = **one agency** (the first registered user is its admin).
 
 ## Contents
 
-- [Run with Docker](#run-with-docker)
+- [Before you begin](#before-you-begin)
+- [Install](#install)
+- [Access your install](#access-your-install)
+- [Secure your install](#secure-your-install)
+- [Go to production (HTTPS)](#go-to-production-https)
 - [Environment variables](#environment-variables)
-- [Day-to-day operation](#day-to-day-operation)
-- [Backup and restore](#backup-and-restore)
+- [Manage your install](#manage-your-install)
+- [Backups](#backups)
+- [Upgrade](#upgrade)
+- [Uninstall](#uninstall)
 - [Run without Docker](#run-without-docker)
 - [Connect WhatsApp](#connect-whatsapp)
 - [Tests](#tests)
-- [Security](#security)
 - [WhatsApp / Baileys caveats](#whatsapp--baileys-caveats)
 
-## Run with Docker
+## Before you begin
 
-Requirements: Docker Desktop (macOS/Windows) or Docker Engine + Compose plugin
-(Linux). Check it is running with `docker compose version`.
+You need a host with Docker:
+
+- macOS / Windows — [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+- Linux / a server — Docker Engine with the Compose plugin.
+
+Check it is running:
+
+```bash
+docker --version
+docker compose version
+```
+
+For a public deployment you also need a **domain** and a server with ports
+**80** and **443** open (see [Go to production](#go-to-production-https)).
+
+## Install
 
 ```bash
 git clone <REPOSITORY_URL>
 cd openlivery
 ./scripts/generate-docker-env.sh   # writes .env.docker with random secrets (gitignored)
-make up                            # build and start everything
+make up                            # build, start, run migrations
 ```
 
 `make up` builds the images, starts the four containers, creates the database
-and runs the Alembic migrations. Then open:
+and applies the Alembic migrations. All four should report `healthy`:
 
-- App — http://localhost:3000
-- API docs — http://localhost:8000/docs
-
-The WhatsApp bridge port is never published on the host; only the backend
-reaches it over the private Compose network.
+```bash
+make ps
+```
 
 Override host ports inline when they clash with other services (this keeps the
 browser's API URL in sync automatically):
@@ -47,44 +72,45 @@ browser's API URL in sync automatically):
 API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up
 ```
 
-`make` targets: `up`, `down`, `stop`, `start`, `restart`, `build`, `logs`
-(`SERVICE=api` to filter), `ps`, `migrate`, `test`, `shell-api`, `shell-db`,
-`destroy`, `help`.
+## Access your install
 
-> `NEXT_PUBLIC_API_URL` is baked into the frontend at build time. `make` derives
-> it from `API_PORT`; if you build the web image with raw `docker compose`, pass
-> `NEXT_PUBLIC_API_URL` yourself or it will point at the default port.
+- **App / dashboard** — http://localhost:3000
+- **API docs** — http://localhost:8000/docs
+- **PostgreSQL** — `make shell-db` (or connect to `localhost:5432`)
 
-## Environment variables
+On the first screen choose **Create agency**; that account is the admin. The
+WhatsApp bridge port is never published on the host — only the backend reaches
+it over the private Compose network.
 
-`./scripts/generate-docker-env.sh` fills these with random values. To set them by
-hand, copy `.env.docker.example` to `.env.docker` and replace every `CHANGE_*`.
+## Secure your install
 
-| Variable | Scope | Use |
-| --- | --- | --- |
-| `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | Private network | Main PostgreSQL database. |
-| `POSTGRES_TEST_DB` | Private network | Isolated database for `pytest`. |
-| `SECRET_KEY` | Backend | Signs the agency and portal sessions. |
-| `ENCRYPTION_KEY` | Backend / persisted data | Encrypts API keys, QR and the WhatsApp session. **Must not change** after secrets are stored. |
-| `WHATSAPP_BRIDGE_TOKEN` | Backend + bridge | Authenticates the private backend↔bridge calls. |
-| `FRONTEND_URL` | Backend | Origin allowed by CORS; usually `http://localhost:3000`. |
-| `NEXT_PUBLIC_API_URL` | Browser / frontend build | Address the browser uses to reach the API. |
-| `COOKIE_SECURE` | Backend | `true` behind HTTPS so the session cookie is only sent over TLS. |
-| `COOKIE_SAMESITE` | Backend | `lax` (default). Use `none` when the frontend and API are on different sites (requires `COOKIE_SECURE=true`). |
-| `ACCESS_TOKEN_MINUTES` | Backend | Session lifetime. |
-| `WHATSAPP_LOG_LEVEL` | Bridge | Log level; `silent` avoids exposing sensitive data. |
-| `API_PORT`, `WEB_PORT`, `DB_PORT` | Host | Host ports (defaults `8000` / `3000` / `5432`). |
-| `BIND_HOST` | Host | Bind address: `127.0.0.1` (local) or `0.0.0.0` (expose on a server). |
+Do this before exposing OpenLivery to anyone else.
 
-## Public / HTTPS deployment
+- **Secrets.** `generate-docker-env.sh` fills `SECRET_KEY`, `ENCRYPTION_KEY`,
+  `WHATSAPP_BRIDGE_TOKEN` and `POSTGRES_PASSWORD` with random values. If you set
+  them by hand, use long random strings and never reuse them across installs.
+- ⚠️ **`ENCRYPTION_KEY` must never change** once secrets are stored — it decrypts
+  the provider API keys and the WhatsApp sessions. Losing or changing it makes
+  them unrecoverable.
+- **Keep services private.** Leave `BIND_HOST=127.0.0.1` (the default) so the
+  database, API and frontend are only reachable from the host; expose the app to
+  the internet **only** through the reverse proxy (next section). Never publish
+  the PostgreSQL port on a public interface.
+- **Do not commit `.env.docker`** or any backup that contains it; store it in a
+  secret manager.
+- Provider API keys are encrypted at rest and never returned in full to the
+  browser; the WhatsApp auth state and QR are encrypted too. `WHATSAPP_BRIDGE_TOKEN`
+  authenticates the backend↔bridge calls — do not reuse it as a password or key.
 
-For a server reachable from the internet, the stack includes an optional **Caddy**
-reverse proxy that gets and renews HTTPS certificates automatically and serves the
-whole app from a single domain (frontend + API share one origin, so the session
-cookie just works).
+## Go to production (HTTPS)
 
-1. On a host with Docker, point your domain's DNS (an `A` record) at the server's
-   IP and open ports **80** and **443**.
+The stack includes an optional **Caddy** reverse proxy that obtains and renews
+HTTPS certificates automatically and serves the whole app from a single domain
+(frontend and API share one origin, so the session cookie works with no extra
+config).
+
+1. Point your domain's DNS (an `A` record) at the server's IP and open ports
+   **80** and **443**.
 2. Set the domain in `.env.docker`:
 
    ```bash
@@ -97,31 +123,55 @@ cookie just works).
    make deploy
    ```
 
-`make deploy` starts the base stack plus Caddy using `docker-compose.prod.yml`.
-Caddy issues the TLS certificate on first request and routes `/api/*` to the
+Caddy issues the certificate on the first request and routes `/api/*` to the
 backend and everything else to the frontend. `FRONTEND_URL`, `NEXT_PUBLIC_API_URL`
-and `COOKIE_SECURE=true` are set for the domain automatically, so there is nothing
-else to configure. Keep `BIND_HOST=127.0.0.1` (the default) so only Caddy is
-exposed publicly.
+and `COOKIE_SECURE=true` are configured for the domain automatically.
 
-Under the hood this is `docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d`;
-run it directly if you prefer. To use your own reverse proxy instead, skip the
-prod overlay and set `FRONTEND_URL`, `NEXT_PUBLIC_API_URL` and `COOKIE_SECURE`
-yourself.
+`make deploy` is `docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d`.
+To use your own proxy instead, skip the overlay and set `FRONTEND_URL`,
+`NEXT_PUBLIC_API_URL` and `COOKIE_SECURE` yourself. If the frontend and API end
+up on **different registrable domains**, also set `COOKIE_SAMESITE=none` (which
+requires `COOKIE_SECURE=true`).
 
-Each deployment is a **single agency** (the first registered user is its admin).
-Provider keys are per-agency and brought by the deployer.
+## Environment variables
 
-## Day-to-day operation
+`generate-docker-env.sh` fills the secrets. To set values by hand, copy
+`.env.docker.example` to `.env.docker` and replace every `CHANGE_*`.
+
+| Variable | Scope | Use |
+| --- | --- | --- |
+| `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | Private network | Main PostgreSQL database. |
+| `POSTGRES_TEST_DB` | Private network | Isolated database for `pytest`. |
+| `SECRET_KEY` | Backend | Signs the agency and portal sessions. |
+| `ENCRYPTION_KEY` | Backend / persisted data | Encrypts API keys, QR and the WhatsApp session. **Must not change** after secrets are stored. |
+| `WHATSAPP_BRIDGE_TOKEN` | Backend + bridge | Authenticates the private backend↔bridge calls. |
+| `FRONTEND_URL` | Backend | Origin allowed by CORS. |
+| `NEXT_PUBLIC_API_URL` | Browser / frontend build | Address the browser uses to reach the API (baked at build time). |
+| `COOKIE_SECURE` | Backend | `true` behind HTTPS so the session cookie is only sent over TLS. |
+| `COOKIE_SAMESITE` | Backend | `lax` (default); `none` when the frontend and API are on different sites (requires `COOKIE_SECURE=true`). |
+| `DOMAIN` | Reverse proxy | Public domain for `make deploy`. |
+| `ACCESS_TOKEN_MINUTES` | Backend | Session lifetime. |
+| `WHATSAPP_LOG_LEVEL` | Bridge | Log level; `silent` avoids exposing sensitive data. |
+| `API_PORT`, `WEB_PORT`, `DB_PORT` | Host | Host ports (defaults `8000` / `3000` / `5432`). |
+| `BIND_HOST` | Host | Bind address: `127.0.0.1` (local) or `0.0.0.0` (expose directly). |
+
+## Manage your install
 
 ```bash
-make logs                 # all services (SERVICE=api to filter)
-make down                 # stop and remove containers (keeps data volumes)
+make logs                 # follow logs from all services (SERVICE=api to filter)
+make ps                   # service status
+make stop                 # stop containers (keep them)
+make start                # start stopped containers
+make restart              # restart all services
 make migrate              # apply Alembic migrations in the running api container
-git pull && make up       # update after pulling a new version
+make shell-api            # shell inside the api container
+make shell-db             # psql inside the database
+make down                 # stop and remove containers (keeps data volumes)
 ```
 
-## Backup and restore
+Run `make help` for the full list.
+
+## Backups
 
 Export PostgreSQL without stopping the app:
 
@@ -143,11 +193,23 @@ docker compose --env-file .env.docker exec -T db \
 docker compose --env-file .env.docker start api whatsapp
 ```
 
-Delete a test install (**permanently** removes the database, PDFs, keys and
-WhatsApp sessions in the volumes):
+## Upgrade
 
 ```bash
-make destroy
+git pull
+make up        # or `make deploy` for the HTTPS production setup
+```
+
+New images are built and the backend runs `alembic upgrade head` on start, so
+schema changes are applied automatically. Take a backup first.
+
+## Uninstall
+
+`make down` removes the containers and network but keeps your data. To delete
+**everything** — database, PDFs, keys and WhatsApp sessions in the volumes:
+
+```bash
+make destroy   # irreversible
 ```
 
 ## Run without Docker
@@ -176,9 +238,8 @@ cd apps/whatsapp && npm install && npm run start
 ```
 
 The bridge listens only on `127.0.0.1:3101` and must stay running alongside the
-backend to send and receive messages. See `.env.example` for the full variable
-list (`DATABASE_URL`, `BACKEND_URL`, `WHATSAPP_BRIDGE_URL`, `WHATSAPP_BRIDGE_PORT`,
-`WHATSAPP_BRIDGE_TOKEN`, …).
+backend. See `.env.example` for the full variable list (`DATABASE_URL`,
+`BACKEND_URL`, `WHATSAPP_BRIDGE_URL`, `WHATSAPP_BRIDGE_PORT`, …).
 
 ## Connect WhatsApp
 
@@ -187,7 +248,7 @@ list (`DATABASE_URL`, `BACKEND_URL`, `WHATSAPP_BRIDGE_URL`, `WHATSAPP_BRIDGE_POR
 3. On the phone: **WhatsApp → Settings → Linked devices → Link a device**, scan
    the QR and wait for **Connected**.
 
-Incoming messages appear in the agency **Inbox** and in the client portal. Click
+Incoming messages appear in the agency **Inbox** and the client portal. Click
 **Take over** to answer as a human (the AI pauses) and **Return to AI** to
 resume. On restart the bridge reloads enabled sessions from PostgreSQL and
 reconnects automatically — no new QR unless WhatsApp ends the session, the device
@@ -214,20 +275,6 @@ Re-test the migrations from scratch:
 ```bash
 cd apps/api && alembic downgrade base && alembic upgrade head
 ```
-
-## Security
-
-- Provider API keys are encrypted (key derived from `ENCRYPTION_KEY`) and never
-  returned in full to the browser.
-- The full WhatsApp auth state and the temporary QR are encrypted before being
-  stored in PostgreSQL; the browser only ever receives the temporary QR, and only
-  for an authenticated agency admin.
-- Backend and bridge authenticate with `WHATSAPP_BRIDGE_TOKEN`; do not reuse it as
-  a portal password or an API key.
-- Every query is scoped by `agency_id`; agency and portal endpoints re-check
-  ownership before reading or sending data.
-- Do not commit `.env`, databases, logs or secrets. For a public install enable
-  HTTPS, `secure` cookies, a restrictive CORS policy and strong keys.
 
 ## WhatsApp / Baileys caveats
 


### PR DESCRIPTION
Restructures docs/self-hosting.md into a complete self-hosting guide (install, access, **secure your install**, production HTTPS, manage, backups, upgrade, uninstall, non-Docker, WhatsApp, tests, caveats).