### PR TITLE
Add consistent vertical spacing between top-level page sections

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -51,6 +51,7 @@ h1, h2, h3, .brand { font-family: var(--font-manrope), sans-serif; }
 .user-meta span { color: #808aa4; font-size: 10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .main-content { min-height: 100vh; margin-left: 252px; }
 .page { max-width: 1420px; margin: 0 auto; padding: 43px 44px 64px; }
+.page > * + * { margin-top: 21px; }
 .mobile-menu, .sidebar-close { display: none; }
 .app-loader, .page-loading { min-height: 100vh; display: flex; align-items: center; justify-content: center; gap: 12px; color: var(--muted); }
 .page-loading { min-height: 60vh; }


### PR DESCRIPTION
## Problem
The `.page` container stacked its children as plain blocks with no gap, relying on each section to bring its own margin. Sections that don't (`.dashboard-row`, standalone `.panel`s on the dashboard, the domain section after the portal form, settings sub-sections, tab content) rendered flush against their neighbors — panels appeared stuck together across several views.

## Fix
One rule:

```css
.page > * + * { margin-top: 21px; }
```

Placed early with single-class specificity so existing intentional margins (page-head, section-block, tabs, metrics-grid) still win their ties and collapse normally. It only fills the zero-gap cases, so no regressions to views that already spaced correctly.

## Testing
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)