### PR TITLE
Add GPT-5.6 models and gpt-transcribe

### DIFF
--- a/apps/web/lib/providers.ts
+++ b/apps/web/lib/providers.ts
@@ -6,6 +6,9 @@ export const PROVIDERS = [
     keyPlaceholder: "sk-proj-...",
     keyUrl: "https://platform.openai.com/api-keys",
     models: [
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",
@@ -41,7 +44,7 @@ export type ProviderId = (typeof PROVIDERS)[number]["id"];
 // Transcription models for the audio-recognition capability (OpenAI).
 export const AUDIO_MODELS = ["whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe", "gpt-4o-transcribe-diarize"] as const;
 // Vision-capable models for the image-recognition capability.
-export const IMAGE_MODELS = ["gpt-4.1", "gpt-4.1-mini", "gpt-5.5", "gpt-5.4", "gpt-5", "gpt-5-mini"] as const;
+export const IMAGE_MODELS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-4.1", "gpt-4.1-mini", "gpt-5.5", "gpt-5.4", "gpt-5", "gpt-5-mini"] as const;
 
 export function providerLabel(id: string): string {
   return PROVIDERS.find((p) => p.id === id)?.label ?? id;

--- a/apps/web/lib/providers.ts
+++ b/apps/web/lib/providers.ts
@@ -42,7 +42,7 @@ export const PROVIDERS = [
 export type ProviderId = (typeof PROVIDERS)[number]["id"];
 
 // Transcription models for the audio-recognition capability (OpenAI).
-export const AUDIO_MODELS = ["whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe", "gpt-4o-transcribe-diarize"] as const;
+export const AUDIO_MODELS = ["gpt-transcribe", "whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe", "gpt-4o-transcribe-diarize"] as const;
 // Vision-capable models for the image-recognition capability.
 export const IMAGE_MODELS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-4.1", "gpt-4.1-mini", "gpt-5.5", "gpt-5.4", "gpt-5", "gpt-5-mini"] as const;
 


### PR DESCRIPTION
## What
Adds the new OpenAI models relevant to chatbot agents:

- **Chat/LLM:** `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` (GPT-5.6 frontier family) added to the OpenAI model list. Sol and Terra also added to the vision-capable set (`IMAGE_MODELS`).
- **Transcription:** `gpt-transcribe` added to `AUDIO_MODELS` — the new file-transcription model for inbound voice notes (audio-recognition capability).

## Out of scope (intentionally excluded)
Daybreak/cyber, GPT Image 2, Realtime, TTS, and `gpt-live-transcribe` — none apply to a text chatbot agent whose audio path is file-based `/audio/transcriptions`.

## Notes
- Context window resolves via the existing `gpt-5` prefix (400k); no helper change needed.
- Model-ID strings verified against OpenAI docs.

## Testing
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)