### PR TITLE
Fix the WhatsApp inbound route in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Everything is agency-scoped: `Agency → Users, Clients, AIConnections`; `Client
 
 ### WhatsApp flow
 
-The bridge (`apps/whatsapp/src/manager.ts`) holds live Baileys sessions and is stateful — encrypted session/auth state lives in PostgreSQL (via the backend), and the bridge reloads enabled sessions on startup. Incoming messages: bridge → `POST /api/whatsapp/receive` on the backend → AI reply sent back through the bridge. Backend↔bridge calls authenticate with `WHATSAPP_BRIDGE_TOKEN`. Conversations have a `mode` field: switching to `"human"` pauses the AI so an operator answers from the portal.
+The bridge (`apps/whatsapp/src/manager.ts`) holds live Baileys sessions and is stateful — encrypted session/auth state lives in PostgreSQL (via the backend), and the bridge reloads enabled sessions on startup. Incoming messages: bridge → `POST /api/whatsapp/channels/{channel_id}/inbound` on the backend → AI reply sent back through the bridge. Backend↔bridge calls authenticate with `WHATSAPP_BRIDGE_TOKEN`. Conversations have a `mode` field: switching to `"human"` pauses the AI so an operator answers from the portal.
 
 ### Frontend
 


### PR DESCRIPTION
CLAUDE.md described the WhatsApp inbound path as `POST /api/whatsapp/receive`, but the real endpoint is `POST /api/whatsapp/channels/{channel_id}/inbound` (the bridge calls `/channels/{channelId}/inbound`, see `apps/api/app/routers/whatsapp.py` and `apps/whatsapp/src/manager.ts`). This corrects the architecture note to match the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)