### PR TITLE
Space stacked provider cards in settings

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -306,6 +306,7 @@ textarea { line-height: 1.55; }
 .url-preview button, .url-preview a { display: inline-flex; align-items: center; gap: 5px; color: #5149d1; border: 0; background: transparent; font-size: 12px; }
 
 .section-block { margin-top: 38px; }
+.section-block .form-section + .form-section { margin-top: 16px; }
 .section-heading { margin-bottom: 16px; display: flex; align-items: center; justify-content: space-between; gap: 20px; }
 .section-heading h2 { margin: 0 0 4px; font-size: 20px; }
 .section-heading p { margin: 0; color: #687082; font-size: 14px; }


### PR DESCRIPTION
## Problem
On **Settings → AI provider keys**, the OpenAI and Anthropic cards sat flush against each other with no vertical gap.

## Cause
The provider cards render as consecutive `.form-section` siblings inside `.section-block`, which — unlike `.page-form` / `.settings-form` — has no `gap` between its children. (The earlier `.page > * + *` fix only covers top-level page sections, not these nested cards.)

## Fix
```css
.section-block .form-section + .form-section { margin-top: 16px; }
```
Scoped to `.section-block` (used only on the settings page), so no other view is affected. Verified other stacked-card views (agent detail, client forms) already use gap containers and were not affected.

## Testing
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)