### PR TITLE
Add unread count and preview fields to conversation models and update…

### DIFF
--- a/apps/api/app/routers/conversations.py
+++ b/apps/api/app/routers/conversations.py
@@ -1,7 +1,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile, status
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..database import get_db
@@ -80,15 +80,22 @@ def inbox(
         func.row_number().over(partition_by=Message.conversation_id, order_by=Message.created_at.desc()).label("rn"),
     ).subquery()
     last = select(ranked).where(ranked.c.rn == 1).subquery()
+    unread_counts = (
+        select(Message.conversation_id.label("cid"), func.count(Message.id).label("n"))
+        .join(Conversation, Conversation.id == Message.conversation_id)
+        .where(
+            Message.sender_type == "visitor",
+            or_(Conversation.operator_read_at.is_(None), Message.created_at > Conversation.operator_read_at),
+        )
+        .group_by(Message.conversation_id)
+    ).subquery()
+    unread_count = func.coalesce(unread_counts.c.n, 0)
 
-    is_unread = and_(
-        last.c.sender_type == "visitor",
-        or_(Conversation.operator_read_at.is_(None), last.c.created_at > Conversation.operator_read_at),
-    )
     query = (
-        select(Conversation, Agent.name, last.c.content, is_unread.label("unread"))
+        select(Conversation, Agent.name, last.c.content, unread_count.label("unread_count"))
         .join(Agent, Agent.id == Conversation.agent_id)
         .outerjoin(last, last.c.cid == Conversation.id)
+        .outerjoin(unread_counts, unread_counts.c.cid == Conversation.id)
         .where(Conversation.agency_id == user.agency_id)
     )
     if agent_id:
@@ -98,7 +105,7 @@ def inbox(
     if mode in ("ai", "human"):
         query = query.where(Conversation.mode == mode)
     if unread:
-        query = query.where(is_unread)
+        query = query.where(unread_count > 0)
     if search and search.strip():
         term = f"%{search.strip().lower()}%"
         query = query.where(
@@ -120,10 +127,11 @@ def inbox(
             "channel": conv.channel,
             "mode": conv.mode,
             "preview": (content or "")[:140].strip(),
-            "unread": bool(row_unread),
+            "unread": int(row_unread_count) > 0,
+            "unread_count": int(row_unread_count),
             "updated_at": conv.updated_at,
         }
-        for conv, agent_name, content, row_unread in rows
+        for conv, agent_name, content, row_unread_count in rows
     ]
 
 

--- a/apps/api/app/routers/portal.py
+++ b/apps/api/app/routers/portal.py
@@ -1,7 +1,7 @@
 import uuid
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..config import get_settings
@@ -129,9 +129,22 @@ def portal_agents(slug: str, client: Client = Depends(_portal_client), db: Sessi
 
 @router.get("/{slug}/conversations", response_model=list[ConversationOut])
 def portal_conversations(slug: str, client: Client = Depends(_portal_client), db: Session = Depends(get_db)):
-    return db.scalars(
-        select(Conversation).where(Conversation.client_id == client.id).order_by(Conversation.updated_at.desc())
+    ranked = select(
+        Message.conversation_id.label("cid"),
+        Message.content.label("content"),
+        func.row_number().over(partition_by=Message.conversation_id, order_by=Message.created_at.desc()).label("rn"),
+    ).subquery()
+    last = select(ranked).where(ranked.c.rn == 1).subquery()
+    rows = db.execute(
+        select(Conversation, last.c.content)
+        .outerjoin(last, last.c.cid == Conversation.id)
+        .where(Conversation.client_id == client.id)
+        .order_by(Conversation.updated_at.desc())
     ).all()
+    return [
+        ConversationOut.model_validate(conv).model_copy(update={"preview": (content or "")[:140].strip()})
+        for conv, content in rows
+    ]
 
 
 @router.get("/{slug}/conversations/{conversation_id}", response_model=ConversationDetail)

--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -279,6 +279,7 @@ class ConversationOut(ORMModel):
     contact_name: str | None = None
     created_at: datetime
     updated_at: datetime
+    preview: str = ""
 
 
 class SourceOut(BaseModel):
@@ -313,6 +314,7 @@ class ConversationInboxOut(BaseModel):
     mode: str
     preview: str = ""
     unread: bool = False
+    unread_count: int = 0
     updated_at: datetime
 
 

--- a/apps/api/tests/test_flows.py
+++ b/apps/api/tests/test_flows.py
@@ -222,10 +222,12 @@ def test_widget_public_chat_and_gating(authenticated_client: TestClient, monkeyp
     client.post(f"/api/widget/{public_id}/messages", json={"session_id": "s1", "content": "still there?"})
     inbox_row = next(row for row in client.get("/api/conversations/inbox").json() if row["id"] == conversation_id)
     assert inbox_row["unread"] is True
+    assert inbox_row["unread_count"] >= 1
 
     assert client.post(f"/api/conversations/{conversation_id}/read").status_code == 204
     inbox_row = next(row for row in client.get("/api/conversations/inbox").json() if row["id"] == conversation_id)
     assert inbox_row["unread"] is False
+    assert inbox_row["unread_count"] == 0
 
 
 def test_inbox_pagination_and_search(authenticated_client: TestClient):
@@ -524,6 +526,7 @@ def test_white_label_portal_and_human_takeover(authenticated_client: TestClient)
     inbox = client.get(f"/api/portal/{customer['portal_slug']}/conversations")
     assert inbox.status_code == 200
     assert inbox.json()[0]["id"] == conversation["id"]
+    assert inbox.json()[0]["preview"] == ""
 
     takeover = client.patch(
         f"/api/portal/{customer['portal_slug']}/conversations/{conversation['id']}/mode",
@@ -536,6 +539,8 @@ def test_white_label_portal_and_human_takeover(authenticated_client: TestClient)
     )
     assert replied.status_code == 200
     assert replied.json()["messages"][-1]["sender_type"] == "human"
+    inbox_after = client.get(f"/api/portal/{customer['portal_slug']}/conversations")
+    assert inbox_after.json()[0]["preview"] == "Hi, I'm part of the Luna team."
 
 
 def test_provider_test_returns_models(authenticated_client: TestClient, monkeypatch):

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -468,14 +468,14 @@ textarea { line-height: 1.55; }
 .inbox-tabs button.active em { color: var(--ink); background: white; }
 .inbox-row.unread strong { font-weight: 750; }
 .inbox-row.unread .inbox-row-preview { color: var(--ink); }
-.inbox-unread-dot { flex: 0 0 auto; align-self: center; width: 8px; height: 8px; border-radius: 50%; background: var(--purple); }
+.inbox-unread-count { flex: 0 0 auto; align-self: center; min-width: 18px; height: 18px; padding: 0 5px; display: inline-flex; align-items: center; justify-content: center; border-radius: 20px; color: white; background: var(--purple); font-size: 10px; font-weight: 700; line-height: 1; }
 .inbox-thread { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
 .inbox-thread > header { min-height: 62px; padding: 0 18px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); }
 .inbox-thread > header div { display: flex; flex-direction: column; }
 .inbox-thread header small { color: #7d8594; }
 .mode-toggle { min-height: 35px; padding: 0 12px; color: #4f46cf; border: 1px solid #cac6ff; border-radius: 7px; background: #f4f3ff; }
 .mode-toggle.human { color: #087a5e; border-color: #a9ddce; background: #eaf8f3; }
-.inbox-messages { padding: 22px; display: flex; flex: 1; overflow: auto; flex-direction: column; gap: 14px; }
+.inbox-messages { padding: 22px; display: flex; flex: 1; overflow: auto; overflow-anchor: none; flex-direction: column; gap: 14px; }
 .inbox-message { max-width: 75%; }
 .inbox-message.user { align-self: flex-end; }
 .inbox-message small { color: #7a8291; font-size: 11px; }
@@ -518,11 +518,15 @@ textarea { line-height: 1.55; }
 .portal-inbox > aside button > span:last-child { min-width: 0; display: flex; flex-direction: column; }
 .portal-inbox > aside strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .portal-inbox > aside small { color: #7b8391; }
+.portal-inbox-row-top { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.portal-inbox-row-top strong { flex: 1 1 auto; }
+.portal-inbox-row-top time { flex: 0 0 auto; color: #9aa1af; font-size: 11px; }
+.portal-inbox-preview { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .portal-inbox > section { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
 .portal-inbox > section > header { min-height: 64px; padding: 0 18px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); }
 .portal-inbox > section > header div { display: flex; flex-direction: column; }
 .portal-inbox > section > header small { color: #7d8594; }
-.portal-messages { padding: 24px; display: flex; flex: 1; overflow: auto; flex-direction: column; gap: 15px; }
+.portal-messages { padding: 24px; display: flex; flex: 1; overflow: auto; overflow-anchor: none; flex-direction: column; gap: 15px; }
 .portal-messages article { max-width: 76%; }
 .portal-messages article.user { align-self: flex-end; }
 .portal-messages small { color: #7a8291; font-size: 11px; }

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -5,7 +5,7 @@ import { Inbox as InboxIcon, LoaderCircle, Search, UserRound } from "lucide-reac
 import { PageHead } from "@/components/ui";
 import { useToast } from "@/components/toast";
 import { api, messageFrom } from "@/lib/api";
-import { formatWhen, isSameOpenThread } from "@/lib/datetime";
+import { formatWhen, isNearBottom, isSameOpenThread } from "@/lib/datetime";
 import { useLanguage, useT } from "@/lib/i18n";
 import type { Agent, Conversation, ConversationInbox } from "@/types";
 
@@ -55,11 +55,18 @@ export default function InboxPage() {
   const selectedIdRef = useRef<string | null>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
   useEffect(() => { selectedIdRef.current = selected?.id ?? null; }, [selected]);
+  const wasNearBottomRef = useRef(true);
+  useEffect(() => {
+    const el = messagesRef.current;
+    if (el) { const handler = () => { wasNearBottomRef.current = isNearBottom(el); }; el.addEventListener("scroll", handler, { passive: true }); return () => el.removeEventListener("scroll", handler); }
+  }, [selected?.id]);
   useEffect(() => {
     const el = messagesRef.current;
     if (!el) return;
-    const frame = requestAnimationFrame(() => { el.scrollTop = el.scrollHeight; });
-    return () => cancelAnimationFrame(frame);
+    if (wasNearBottomRef.current) {
+      const frame = requestAnimationFrame(() => { el.scrollTop = el.scrollHeight; });
+      return () => cancelAnimationFrame(frame);
+    }
   }, [selected?.id, selected?.messages?.at(-1)?.id]);
 
   const loadFirst = useCallback(async (opts?: { silent?: boolean }) => {
@@ -80,9 +87,12 @@ export default function InboxPage() {
     try {
       const conv = await api<Conversation>(`/conversations/${id}`);
       if (selectedIdRef.current !== id) return;
-      setSelected((prev) => (isSameOpenThread(prev, conv) ? prev : conv));
-      setItems((rows) => rows.map((row) => (row.id === id ? { ...row, unread: false, unread_count: 0 } : row)));
-      api(`/conversations/${id}/read`, { method: "POST" }).catch(() => {});
+      setSelected((prev) => {
+        if (isSameOpenThread(prev, conv)) return prev;
+        setItems((rows) => rows.map((row) => (row.id === id ? { ...row, unread: false, unread_count: 0 } : row)));
+        api(`/conversations/${id}/read`, { method: "POST" }).catch(() => {});
+        return conv;
+      });
     } catch {
       // Poll failures should not interrupt the open thread.
     }

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -5,21 +5,16 @@ import { Inbox as InboxIcon, LoaderCircle, Search, UserRound } from "lucide-reac
 import { PageHead } from "@/components/ui";
 import { useToast } from "@/components/toast";
 import { api, messageFrom } from "@/lib/api";
-import { useT } from "@/lib/i18n";
+import { formatWhen, isSameOpenThread } from "@/lib/datetime";
+import { useLanguage, useT } from "@/lib/i18n";
 import type { Agent, Conversation, ConversationInbox } from "@/types";
 
 const LIMIT = 30;
-
-function formatWhen(iso: string): string {
-  const date = new Date(iso);
-  const sameDay = date.toDateString() === new Date().toDateString();
-  return sameDay
-    ? date.toLocaleTimeString("es", { hour: "2-digit", minute: "2-digit" })
-    : date.toLocaleDateString("es", { day: "numeric", month: "short" });
-}
+const POLL_MS = 8000;
 
 export default function InboxPage() {
   const t = useT();
+  const { lang } = useLanguage();
   const toast = useToast();
   const [agents, setAgents] = useState<Agent[]>([]);
   const [items, setItems] = useState<ConversationInbox[]>([]);
@@ -57,21 +52,54 @@ export default function InboxPage() {
     return params.toString();
   }, [agentId, channel, tab, search]);
 
-  const loadFirst = useCallback(async () => {
-    setLoading(true);
+  const selectedIdRef = useRef<string | null>(null);
+  const messagesRef = useRef<HTMLDivElement>(null);
+  useEffect(() => { selectedIdRef.current = selected?.id ?? null; }, [selected]);
+  useEffect(() => {
+    const el = messagesRef.current;
+    if (!el) return;
+    const frame = requestAnimationFrame(() => { el.scrollTop = el.scrollHeight; });
+    return () => cancelAnimationFrame(frame);
+  }, [selected?.id, selected?.messages?.at(-1)?.id]);
+
+  const loadFirst = useCallback(async (opts?: { silent?: boolean }) => {
+    if (!opts?.silent) setLoading(true);
     try {
       const rows = await api<ConversationInbox[]>(`/conversations/inbox?${buildParams(0)}`);
       setItems(rows); setOffset(rows.length); setHasMore(rows.length === LIMIT);
-    } catch (err) { toast.error(messageFrom(err)); } finally { setLoading(false); }
+    } catch (err) {
+      if (!opts?.silent) toast.error(messageFrom(err));
+    } finally {
+      if (!opts?.silent) setLoading(false);
+    }
   }, [buildParams, toast]);
+
+  const refreshSelected = useCallback(async () => {
+    const id = selectedIdRef.current;
+    if (!id) return;
+    try {
+      const conv = await api<Conversation>(`/conversations/${id}`);
+      if (selectedIdRef.current !== id) return;
+      setSelected((prev) => (isSameOpenThread(prev, conv) ? prev : conv));
+      setItems((rows) => rows.map((row) => (row.id === id ? { ...row, unread: false, unread_count: 0 } : row)));
+      api(`/conversations/${id}/read`, { method: "POST" }).catch(() => {});
+    } catch {
+      // Poll failures should not interrupt the open thread.
+    }
+  }, []);
 
   useEffect(() => { loadFirst(); }, [loadFirst]);
 
-  // Live refresh of the first page (skipped once the user scrolls into older pages).
+  // Live refresh of the first page and the open thread (skipped once the user scrolls into older pages).
   useEffect(() => {
-    const id = setInterval(() => { if (offset <= LIMIT) loadFirst(); }, 12000);
+    const id = setInterval(() => {
+      if (offset <= LIMIT) {
+        loadFirst({ silent: true });
+        refreshSelected();
+      }
+    }, POLL_MS);
     return () => clearInterval(id);
-  }, [loadFirst, offset]);
+  }, [loadFirst, refreshSelected, offset]);
 
   async function loadMore() {
     if (loadingMore || !hasMore) return;
@@ -88,15 +116,16 @@ export default function InboxPage() {
   }
 
   async function choose(id: string) {
+    selectedIdRef.current = id;
     setSelected(await api<Conversation>(`/conversations/${id}`));
-    setItems((rows) => rows.map((row) => (row.id === id ? { ...row, unread: false } : row)));
+    setItems((rows) => rows.map((row) => (row.id === id ? { ...row, unread: false, unread_count: 0 } : row)));
     api(`/conversations/${id}/read`, { method: "POST" }).catch(() => {});
   }
 
   async function toggleMode(next: "ai" | "human") {
     if (!selected) return;
     setSelected(await api<Conversation>(`/conversations/${selected.id}/mode`, { method: "PATCH", body: JSON.stringify({ mode: next }) }));
-    loadFirst();
+    loadFirst({ silent: true });
   }
 
   const composerRef = useRef<HTMLInputElement>(null);
@@ -109,7 +138,7 @@ export default function InboxPage() {
     try {
       setSelected(await api<Conversation>(`/conversations/${selected.id}/reply`, { method: "POST", body: JSON.stringify({ content: data.get("content") }) }));
       form.reset();
-      loadFirst();
+      loadFirst({ silent: true });
     } catch (err) { toast.error(messageFrom(err)); } finally { setBusy(false); composerRef.current?.focus(); }
   }
 
@@ -136,11 +165,11 @@ export default function InboxPage() {
               <button key={item.id} className={`inbox-row ${selected?.id === item.id ? "active" : ""} ${item.unread ? "unread" : ""}`} onClick={() => choose(item.id)}>
                 <span className="entity-avatar tiny"><UserRound size={15} /></span>
                 <span className="inbox-row-body">
-                  <span className="inbox-row-top"><strong>{item.contact_name || item.title}</strong><time>{formatWhen(item.updated_at)}</time></span>
+                  <span className="inbox-row-top"><strong>{item.contact_name || item.title}</strong><time>{formatWhen(item.updated_at, lang)}</time></span>
                   <small className="inbox-row-preview">{item.preview || t("inbox.noMessages")}</small>
                   <small className="inbox-row-meta">{item.agent_name} · {channelLabel(item.channel)} <span className={`mini-badge ${item.mode}`}>{item.mode === "human" ? t("inbox.modeHuman") : t("inbox.modeAi")}</span></small>
                 </span>
-                {item.unread && <span className="inbox-unread-dot" />}
+                {item.unread_count > 0 && selected?.id !== item.id && <span className="inbox-unread-count" aria-label={t("inbox.unreadCount", { count: item.unread_count })}>{item.unread_count > 99 ? "99+" : item.unread_count}</span>}
               </button>
             ))}
             {loadingMore && <div className="no-conversations"><LoaderCircle className="spin" size={15} /></div>}
@@ -154,10 +183,10 @@ export default function InboxPage() {
               <div><strong>{selected.contact_name || selected.title}</strong><small>{channelLabel(selected.channel)}</small></div>
               <button className={`mode-toggle ${selected.mode}`} onClick={() => toggleMode(selected.mode === "ai" ? "human" : "ai")}>{selected.mode === "ai" ? t("inbox.takeControl") : t("inbox.returnToAi")}</button>
             </header>
-            <div className="inbox-messages">
+            <div className="inbox-messages" ref={messagesRef}>
               {selected.messages?.map((message) => (
                 <div key={message.id} className={`inbox-message ${message.role}`}>
-                  <small>{message.sender_name || (message.role === "assistant" ? t("inbox.senderAgent") : t("inbox.senderVisitor"))} · {formatWhen(message.created_at)}</small>
+                  <small>{message.sender_name || (message.role === "assistant" ? t("inbox.senderAgent") : t("inbox.senderVisitor"))} · {formatWhen(message.created_at, lang)}</small>
                   <p>{message.content}</p>
                 </div>
               ))}

--- a/apps/web/app/portal/[slug]/page.tsx
+++ b/apps/web/app/portal/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import { Bot, Building2, Inbox, LoaderCircle, LogOut, MessageSquareText, Send, ShieldCheck, UserRound } from "lucide-react";
 import { Alert, EmptyState } from "@/components/ui";
 import { api, ApiError, messageFrom } from "@/lib/api";
-import { formatWhen, isSameOpenThread } from "@/lib/datetime";
+import { formatWhen, isNearBottom, isSameOpenThread } from "@/lib/datetime";
 import { useLanguage, useT } from "@/lib/i18n";
 import type { Conversation, PortalPublic } from "@/types";
 
@@ -39,11 +39,18 @@ function PortalInbox({ slug, portal, logout }: { slug: string; portal: PortalPub
   const selectedIdRef = useRef<string | null>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
   useEffect(() => { selectedIdRef.current = selected?.id ?? null; }, [selected]);
+  const wasNearBottomRef = useRef(true);
+  useEffect(() => {
+    const el = messagesRef.current;
+    if (el) { const handler = () => { wasNearBottomRef.current = isNearBottom(el); }; el.addEventListener("scroll", handler, { passive: true }); return () => el.removeEventListener("scroll", handler); }
+  }, [selected?.id]);
   useEffect(() => {
     const el = messagesRef.current;
     if (!el) return;
-    const frame = requestAnimationFrame(() => { el.scrollTop = el.scrollHeight; });
-    return () => cancelAnimationFrame(frame);
+    if (wasNearBottomRef.current) {
+      const frame = requestAnimationFrame(() => { el.scrollTop = el.scrollHeight; });
+      return () => cancelAnimationFrame(frame);
+    }
   }, [selected?.id, selected?.messages?.at(-1)?.id]);
 
   const refresh = useCallback(async () => {

--- a/apps/web/app/portal/[slug]/page.tsx
+++ b/apps/web/app/portal/[slug]/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import { Bot, Building2, Inbox, LoaderCircle, LogOut, MessageSquareText, Send, ShieldCheck, UserRound } from "lucide-react";
 import { Alert, EmptyState } from "@/components/ui";
 import { api, ApiError, messageFrom } from "@/lib/api";
-import { useT } from "@/lib/i18n";
+import { formatWhen, isSameOpenThread } from "@/lib/datetime";
+import { useLanguage, useT } from "@/lib/i18n";
 import type { Conversation, PortalPublic } from "@/types";
+
+const POLL_MS = 8000;
 
 type Session = { client_id: string; client_name: string; portal_slug: string; agency_name: string };
 
@@ -28,14 +31,42 @@ export default function PortalPage() {
 
 function PortalInbox({ slug, portal, logout }: { slug: string; portal: PortalPublic; logout: () => void }) {
   const t = useT();
+  const { lang } = useLanguage();
   const [items, setItems] = useState<Conversation[]>([]);
   const [selected, setSelected] = useState<Conversation | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
-  const load = async () => { const rows = await api<Conversation[]>(`/portal/${slug}/conversations`); setItems(rows); if (rows[0] && !selected) setSelected(await api<Conversation>(`/portal/${slug}/conversations/${rows[0].id}`)); };
-  useEffect(() => { load(); }, [slug]);
-  async function choose(item: Conversation) { setSelected(await api<Conversation>(`/portal/${slug}/conversations/${item.id}`)); }
-  async function setMode(mode: "ai" | "human") { if (!selected) return; setSelected(await api<Conversation>(`/portal/${slug}/conversations/${selected.id}/mode`, { method: "PATCH", body: JSON.stringify({ mode }) })); await load(); }
-  async function reply(event: FormEvent<HTMLFormElement>) { event.preventDefault(); if (!selected) return; const form = event.currentTarget; const data = new FormData(form); setBusy(true); setError(""); try { setSelected(await api<Conversation>(`/portal/${slug}/conversations/${selected.id}/reply`, { method: "POST", body: JSON.stringify({ content: data.get("content") }) })); form.reset(); await load(); } catch (err) { setError(messageFrom(err)); } finally { setBusy(false); } }
-  return <main className="portal-app" style={{ "--portal-color": portal.agency_brand_color } as React.CSSProperties}><aside className="portal-nav"><div className="portal-brand">{portal.agency_logo_url ? <img src={`${portal.agency_logo_url}`} alt="Logo" /> : <span>{portal.agency_name.slice(0, 1)}</span>}<strong>{portal.client_name}</strong></div><nav><a className="active"><Inbox size={18} /> {t("portal.inbox.nav.inbox")}</a><a className="disabled"><Bot size={18} /> {t("portal.inbox.nav.agents")}</a></nav><button onClick={logout}><LogOut size={17} /> {t("portal.inbox.nav.logout")}</button></aside><section className="portal-main"><header><div><small>{t("portal.inbox.header.eyebrow")}</small><h1>{portal.portal_title}</h1></div><span>{t("portal.inbox.header.conversationsCount", { count: items.length })}</span></header>{items.length ? <div className="portal-inbox"><aside>{items.map((item) => <button key={item.id} onClick={() => choose(item)} className={selected?.id === item.id ? "active" : ""}><span className="entity-avatar tiny"><UserRound size={15} /></span><span><strong>{item.title}</strong><small>{item.mode === "human" ? t("portal.inbox.list.humanSupport") : t("portal.inbox.list.aiAgent")} · {new Date(item.updated_at).toLocaleDateString("es")}</small></span></button>)}</aside><section>{selected && <><header><div><strong>{selected.title}</strong><small>{t("portal.inbox.conversation.channel", { channel: selected.channel })}</small></div><button className={`mode-toggle ${selected.mode}`} onClick={() => setMode(selected.mode === "ai" ? "human" : "ai")}>{selected.mode === "ai" ? t("portal.inbox.conversation.takeControl") : t("portal.inbox.conversation.returnToAi")}</button></header><div className="portal-messages">{selected.messages?.map((message) => <article key={message.id} className={message.role}><small>{message.sender_name || (message.role === "assistant" ? t("portal.inbox.conversation.agent") : t("portal.inbox.conversation.visitor"))}</small><p>{message.content}</p></article>)}</div>{error && <Alert>{error}</Alert>}<form onSubmit={reply} className="portal-composer"><input name="content" required disabled={selected.mode !== "human" || busy} placeholder={selected.mode === "human" ? t("portal.inbox.conversation.replyPlaceholder") : t("portal.inbox.conversation.takeControlToReply")} /><button disabled={selected.mode !== "human" || busy}>{busy ? <LoaderCircle className="spin" size={18} /> : <Send size={18} />}</button></form></>}</section></div> : <EmptyState icon={<Inbox />} title={t("portal.inbox.empty.title")} description={t("portal.inbox.empty.description")} />}</section></main>;
+  const selectedIdRef = useRef<string | null>(null);
+  const messagesRef = useRef<HTMLDivElement>(null);
+  useEffect(() => { selectedIdRef.current = selected?.id ?? null; }, [selected]);
+  useEffect(() => {
+    const el = messagesRef.current;
+    if (!el) return;
+    const frame = requestAnimationFrame(() => { el.scrollTop = el.scrollHeight; });
+    return () => cancelAnimationFrame(frame);
+  }, [selected?.id, selected?.messages?.at(-1)?.id]);
+
+  const refresh = useCallback(async () => {
+    const rows = await api<Conversation[]>(`/portal/${slug}/conversations`);
+    setItems(rows);
+    const openId = selectedIdRef.current ?? rows[0]?.id;
+    if (!openId) return;
+    const conv = await api<Conversation>(`/portal/${slug}/conversations/${openId}`);
+    if (selectedIdRef.current && selectedIdRef.current !== openId) return;
+    setSelected((prev) => (isSameOpenThread(prev, conv) ? prev : conv));
+  }, [slug]);
+
+  useEffect(() => { refresh().catch((err) => setError(messageFrom(err))); }, [refresh]);
+  useEffect(() => {
+    const id = setInterval(() => { refresh().catch(() => {}); }, POLL_MS);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  async function choose(item: Conversation) {
+    selectedIdRef.current = item.id;
+    setSelected(await api<Conversation>(`/portal/${slug}/conversations/${item.id}`));
+  }
+  async function setMode(mode: "ai" | "human") { if (!selected) return; setSelected(await api<Conversation>(`/portal/${slug}/conversations/${selected.id}/mode`, { method: "PATCH", body: JSON.stringify({ mode }) })); await refresh(); }
+  async function reply(event: FormEvent<HTMLFormElement>) { event.preventDefault(); if (!selected) return; const form = event.currentTarget; const data = new FormData(form); setBusy(true); setError(""); try { setSelected(await api<Conversation>(`/portal/${slug}/conversations/${selected.id}/reply`, { method: "POST", body: JSON.stringify({ content: data.get("content") }) })); form.reset(); await refresh(); } catch (err) { setError(messageFrom(err)); } finally { setBusy(false); } }
+  return <main className="portal-app" style={{ "--portal-color": portal.agency_brand_color } as React.CSSProperties}><aside className="portal-nav"><div className="portal-brand">{portal.agency_logo_url ? <img src={`${portal.agency_logo_url}`} alt="Logo" /> : <span>{portal.agency_name.slice(0, 1)}</span>}<strong>{portal.client_name}</strong></div><nav><a className="active"><Inbox size={18} /> {t("portal.inbox.nav.inbox")}</a><a className="disabled"><Bot size={18} /> {t("portal.inbox.nav.agents")}</a></nav><button onClick={logout}><LogOut size={17} /> {t("portal.inbox.nav.logout")}</button></aside><section className="portal-main"><header><div><small>{t("portal.inbox.header.eyebrow")}</small><h1>{portal.portal_title}</h1></div><span>{t("portal.inbox.header.conversationsCount", { count: items.length })}</span></header>{items.length ? <div className="portal-inbox"><aside>{items.map((item) => <button key={item.id} onClick={() => choose(item)} className={selected?.id === item.id ? "active" : ""}><span className="entity-avatar tiny"><UserRound size={15} /></span><span><span className="portal-inbox-row-top"><strong>{item.title}</strong><time>{formatWhen(item.updated_at, lang)}</time></span><small className="portal-inbox-preview">{item.preview || t("portal.inbox.list.noMessages")}</small><small>{item.mode === "human" ? t("portal.inbox.list.humanSupport") : t("portal.inbox.list.aiAgent")}</small></span></button>)}</aside><section>{selected && <><header><div><strong>{selected.title}</strong><small>{t("portal.inbox.conversation.channel", { channel: selected.channel })}</small></div><button className={`mode-toggle ${selected.mode}`} onClick={() => setMode(selected.mode === "ai" ? "human" : "ai")}>{selected.mode === "ai" ? t("portal.inbox.conversation.takeControl") : t("portal.inbox.conversation.returnToAi")}</button></header><div className="portal-messages" ref={messagesRef}>{selected.messages?.map((message) => <article key={message.id} className={message.role}><small>{message.sender_name || (message.role === "assistant" ? t("portal.inbox.conversation.agent") : t("portal.inbox.conversation.visitor"))} · {formatWhen(message.created_at, lang)}</small><p>{message.content}</p></article>)}</div>{error && <Alert>{error}</Alert>}<form onSubmit={reply} className="portal-composer"><input name="content" required disabled={selected.mode !== "human" || busy} placeholder={selected.mode === "human" ? t("portal.inbox.conversation.replyPlaceholder") : t("portal.inbox.conversation.takeControlToReply")} /><button disabled={selected.mode !== "human" || busy}>{busy ? <LoaderCircle className="spin" size={18} /> : <Send size={18} />}</button></form></>}</section></div> : <EmptyState icon={<Inbox />} title={t("portal.inbox.empty.title")} description={t("portal.inbox.empty.description")} />}</section></main>;
 }

--- a/apps/web/lib/datetime.ts
+++ b/apps/web/lib/datetime.ts
@@ -1,0 +1,20 @@
+import type { Conversation } from "@/types";
+
+/** Relative-ish timestamps for inbox rows and bubbles. */
+export function formatWhen(iso: string, locale: string = "en"): string {
+  const date = new Date(iso);
+  const time = date.toLocaleTimeString(locale, { hour: "2-digit", minute: "2-digit" });
+  const sameDay = date.toDateString() === new Date().toDateString();
+  if (sameDay) return time;
+  const day = date.toLocaleDateString(locale, { day: "numeric", month: "short" });
+  return `${day} · ${time}`;
+}
+
+/** True when a poll result should not replace the open thread (avoids scroll jumps). */
+export function isSameOpenThread(prev: Conversation | null, next: Conversation): boolean {
+  if (!prev || prev.id !== next.id || prev.mode !== next.mode) return false;
+  const prevMessages = prev.messages ?? [];
+  const nextMessages = next.messages ?? [];
+  if (prevMessages.length !== nextMessages.length) return false;
+  return prevMessages.at(-1)?.id === nextMessages.at(-1)?.id;
+}

--- a/apps/web/lib/datetime.ts
+++ b/apps/web/lib/datetime.ts
@@ -18,3 +18,8 @@ export function isSameOpenThread(prev: Conversation | null, next: Conversation):
   if (prevMessages.length !== nextMessages.length) return false;
   return prevMessages.at(-1)?.id === nextMessages.at(-1)?.id;
 }
+
+/** True when the scroll container is near the bottom (within a threshold). */
+export function isNearBottom(el: HTMLElement, threshold: number = 150): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+}

--- a/apps/web/lib/i18n/dicts/inbox.ts
+++ b/apps/web/lib/i18n/dicts/inbox.ts
@@ -32,6 +32,7 @@ const en = {
   composerLocked: "Take over to reply",
   send: "Send",
   loading: "Loading conversations…",
+  unreadCount: "{count} unread",
 };
 
 const es: typeof en = {
@@ -67,6 +68,7 @@ const es: typeof en = {
   composerLocked: "Toma el control para responder",
   send: "Enviar",
   loading: "Cargando conversaciones…",
+  unreadCount: "{count} no leídos",
 };
 
 export const inbox = { en, es };

--- a/apps/web/lib/i18n/dicts/portal.ts
+++ b/apps/web/lib/i18n/dicts/portal.ts
@@ -46,6 +46,7 @@ const en = {
     list: {
       humanSupport: "Human support",
       aiAgent: "AI agent",
+      noMessages: "No messages yet",
     },
     conversation: {
       channel: "Channel: {channel}",
@@ -111,6 +112,7 @@ const es: typeof en = {
     list: {
       humanSupport: "Atención humana",
       aiAgent: "Agente IA",
+      noMessages: "Aún sin mensajes",
     },
     conversation: {
       channel: "Canal: {channel}",

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -106,6 +106,7 @@ export type ConversationInbox = {
   mode: "ai" | "human";
   preview: string;
   unread: boolean;
+  unread_count: number;
   updated_at: string;
 };
 export type Conversation = {
@@ -119,6 +120,7 @@ export type Conversation = {
   contact_name: string | null;
   created_at: string;
   updated_at: string;
+  preview?: string;
   messages?: Message[];
 };
 


### PR DESCRIPTION
## Summary
- Agency inbox and client portal now refresh the open thread (not just the list), without a loading flash.
- Portal list shows last-message preview and date+time; inbox shows unread count.
- Opening a chat scrolls to the latest messages; polling does not replace the thread if nothing changed.

## Why
New WhatsApp / Playground / widget messages were visible in the list but not in the open chat until reload. Portal did not live-update at all.

## Test plan
- [ ] Inbox: leave a chat open, send a message from another channel, list and thread update (~8s)
- [ ] Unread badge appears on chats you have not opened, clears when you open them
- [ ] Portal: same live refresh, plus preview and timestamps