### PR TITLE
Show a channel badge on inbox conversations

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -257,6 +257,11 @@ textarea { line-height: 1.55; }
 .entity-avatar { width: 36px; height: 36px; flex: 0 0 auto; display: grid; place-items: center; color: #5149cf; border: 1px solid #dddafe; border-radius: 7px; background: #f1f0ff; font-size: 13px; font-weight: 700; }
 .entity-avatar.xl { width: 54px; height: 54px; border-radius: 10px; font-size: 17px; }
 .entity-avatar.tiny { width: 30px; height: 30px; border-radius: 50%; }
+.inbox-avatar { position: relative; flex: 0 0 auto; }
+.channel-badge { position: absolute; right: -3px; bottom: -3px; width: 16px; height: 16px; display: grid; place-items: center; color: white; border: 2px solid white; border-radius: 50%; }
+.channel-badge.whatsapp { background: #25a56a; }
+.channel-badge.widget { background: #2f6df0; }
+.channel-badge.playground { background: #7c5cff; }
 .row-arrow { width: 34px; height: 34px; display: grid; place-items: center; color: #737b8b; border-radius: 6px; }
 .row-arrow:hover { color: #5149e8; background: #efeeff; }
 .table-link { color: #4f46d4; font-weight: 550; }

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
-import { Inbox as InboxIcon, LoaderCircle, Search, UserRound } from "lucide-react";
+import { FlaskConical, Globe, Inbox as InboxIcon, LoaderCircle, MessageCircle, Search, UserRound } from "lucide-react";
 import { PageHead } from "@/components/ui";
 import { useToast } from "@/components/toast";
 import { api, messageFrom } from "@/lib/api";
@@ -43,6 +43,13 @@ export default function InboxPage() {
     if (value === "whatsapp") return t("inbox.channelWhatsapp");
     if (value === "widget") return t("inbox.channelWidget");
     return value;
+  };
+
+  const channelIcon = (value: string) => {
+    if (value === "whatsapp") return <MessageCircle size={10} />;
+    if (value === "widget") return <Globe size={10} />;
+    if (value === "playground") return <FlaskConical size={10} />;
+    return <MessageCircle size={10} />;
   };
 
   const buildParams = useCallback((offsetValue: number) => {
@@ -134,7 +141,10 @@ export default function InboxPage() {
           : items.length ? <>
             {items.map((item) => (
               <button key={item.id} className={`inbox-row ${selected?.id === item.id ? "active" : ""} ${item.unread ? "unread" : ""}`} onClick={() => choose(item.id)}>
-                <span className="entity-avatar tiny"><UserRound size={15} /></span>
+                <span className="inbox-avatar">
+                  <span className="entity-avatar tiny"><UserRound size={15} /></span>
+                  <span className={`channel-badge ${item.channel}`} title={channelLabel(item.channel)}>{channelIcon(item.channel)}</span>
+                </span>
                 <span className="inbox-row-body">
                   <span className="inbox-row-top"><strong>{item.contact_name || item.title}</strong><time>{formatWhen(item.updated_at)}</time></span>
                   <small className="inbox-row-preview">{item.preview || t("inbox.noMessages")}</small>


### PR DESCRIPTION
## What
Adds a small channel icon badge over each inbox conversation avatar so you can tell the source channel at a glance:

- **WhatsApp** → message icon (green)
- **Web widget** → globe icon (blue)
- **Playground** → flask icon (purple)

The existing text label (`Agent · Channel`) stays; the badge just makes the channel scannable. Badge has a `title` tooltip with the channel name.

## Where
`apps/web/app/inbox/page.tsx` (the main inbox conversation list) + a few CSS rules in `globals.css` (`.inbox-avatar`, `.channel-badge`).

## Testing
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)