### PR TITLE
Follow an X-Redirect-To response header in the API client

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -22,6 +22,13 @@ export async function api<T>(path: string, options: RequestInit = {}): Promise<T
       ...options.headers,
     },
   });
+  // A deployment can gate a request by returning this header (e.g. a lapsed
+  // subscription); follow it instead of surfacing the error to the caller.
+  const redirectTo = response.headers.get("X-Redirect-To");
+  if (redirectTo && typeof window !== "undefined" && window.location.pathname !== redirectTo) {
+    window.location.assign(redirectTo);
+    return new Promise<T>(() => {}); // never resolves; the page is navigating away
+  }
   if (!response.ok) {
     let message = "An unexpected error occurred";
     try {


### PR DESCRIPTION
## What
The single fetch wrapper (`lib/api.ts`) now checks responses for an `X-Redirect-To` header. If present (and not already on that path), it navigates the browser there and halts, instead of throwing the error to the caller.

## Why
Lets a deployment gate requests declaratively — e.g. a lapsed subscription returns `402` + `X-Redirect-To: /billing`, and the app sends the user to billing cleanly instead of rendering empty pages with error toasts. Generic (the core names no deployment-specific path) and a no-op when the header is absent, so OSS/self-host behavior is unchanged.

## Testing
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)