### PR TITLE
Close public registration after the first agency

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -17,6 +17,10 @@ FRONTEND_URL=http://localhost:3000
 # Optional configuration.
 ACCESS_TOKEN_MINUTES=10080
 WHATSAPP_LOG_LEVEL=silent
+# The instance is single-agency by default: the first registration creates the
+# owner agency and closes public sign-up. Set to true only when one deployment
+# must host many agencies.
+# ALLOW_MULTI_AGENCY=false
 
 # Session cookie flags. Behind an HTTPS reverse proxy set COOKIE_SECURE=true.
 COOKIE_SECURE=false

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ FRONTEND_URL=http://localhost:3000
 COOKIE_SECURE=false
 COOKIE_SAMESITE=lax
 
+# The instance is single-agency by default: the first registration creates the
+# owner agency and closes public sign-up. Set to true only when one deployment
+# must host many agencies.
+# ALLOW_MULTI_AGENCY=false
+
 # Public backend URL used by Next.js
 NEXT_PUBLIC_API_URL=http://localhost:8000
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and are released together.
 
 ## [Unreleased]
 
+### Added
+
+- Public `GET /api/auth/status` endpoint reporting whether the instance still
+  needs its first agency and whether registration is open. The login page uses
+  it to open straight into first-run setup on an empty database and to hide
+  the register tab afterwards.
+
+### Changed
+
+- Self-hosted instances are single-agency by default: the first registration
+  creates the owner agency and closes public sign-up (further attempts return
+  403). Upgrading: instances that already have an agency stop accepting new
+  public registrations; set `ALLOW_MULTI_AGENCY=true` to keep the previous
+  multi-agency behavior.
+
 ## [0.3.0] - 2026-08-20
 
 Upgrading: this release adds a database migration (applied automatically by the

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     # Rate limiting on public/unauthenticated endpoints (per client IP). Disable
     # only for tests or when a proxy in front already enforces limits.
     rate_limit_enabled: bool = True
+    # A self-hosted instance is single-agency by default: the first registration
+    # creates the owner agency and closes public sign-up (like n8n's owner
+    # setup). Enable only when one deployment must host many agencies.
+    allow_multi_agency: bool = False
     # SSRF guard for agent HTTP tools: URLs resolving to private/loopback
     # addresses are rejected. Enable only on self-hosted deployments that need
     # tools to reach internal services.

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -28,6 +28,23 @@ def _set_session_cookie(response: Response, user: User) -> None:
     )
 
 
+def _registration_open(db: Session) -> bool:
+    if get_settings().allow_multi_agency:
+        return True
+    return db.scalar(select(Agency.id).limit(1)) is None
+
+
+@router.get("/status")
+def auth_status(db: Session = Depends(get_db)):
+    # Public: lets the login page decide between first-run setup (no agency
+    # yet) and sign-in only (single-agency instance already configured).
+    has_agency = db.scalar(select(Agency.id).limit(1)) is not None
+    return {
+        "needs_setup": not has_agency,
+        "registration_open": get_settings().allow_multi_agency or not has_agency,
+    }
+
+
 @router.post(
     "/register",
     response_model=UserOut,
@@ -35,6 +52,11 @@ def _set_session_cookie(response: Response, user: User) -> None:
     dependencies=[Depends(login_rate_limit)],
 )
 def register(payload: RegisterRequest, response: Response, db: Session = Depends(get_db)):
+    if not _registration_open(db):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Registration is closed on this instance",
+        )
     email = payload.email.lower()
     if db.scalar(select(User).where(User.email == email)):
         raise HTTPException(status_code=409, detail="A user with that email already exists")

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -34,7 +34,7 @@ def _registration_open(db: Session) -> bool:
     return db.scalar(select(Agency.id).limit(1)) is None
 
 
-@router.get("/status")
+@router.get("/status", dependencies=[Depends(login_rate_limit)])
 def auth_status(db: Session = Depends(get_db)):
     # Public: lets the login page decide between first-run setup (no agency
     # yet) and sign-in only (single-agency instance already configured).

--- a/apps/api/tests/test_flows.py
+++ b/apps/api/tests/test_flows.py
@@ -88,6 +88,51 @@ def test_register_login_logout_and_me(client: TestClient):
     assert client.post("/api/auth/login", json={"email": payload["email"], "password": payload["password"]}).status_code == 200
 
 
+def test_single_agency_instance_closes_registration(client: TestClient):
+    status = client.get("/api/auth/status").json()
+    assert status == {"needs_setup": True, "registration_open": True}
+
+    first = client.post(
+        "/api/auth/register",
+        json={"agency_name": "North Studio", "name": "Laura", "email": "laura@norte.com", "password": "very-secure-key"},
+    )
+    assert first.status_code == 201
+
+    status = client.get("/api/auth/status").json()
+    assert status == {"needs_setup": False, "registration_open": False}
+
+    second = client.post(
+        "/api/auth/register",
+        json={"agency_name": "South Studio", "name": "Mario", "email": "mario@sur.com", "password": "very-secure-key"},
+    )
+    assert second.status_code == 403
+
+    # Existing users still sign in normally.
+    assert client.post("/api/auth/login", json={"email": "laura@norte.com", "password": "very-secure-key"}).status_code == 200
+
+
+def test_multi_agency_flag_keeps_registration_open(client: TestClient):
+    settings = get_settings()
+    settings.allow_multi_agency = True
+    try:
+        first = client.post(
+            "/api/auth/register",
+            json={"agency_name": "North Studio", "name": "Laura", "email": "laura@norte.com", "password": "very-secure-key"},
+        )
+        assert first.status_code == 201
+
+        status = client.get("/api/auth/status").json()
+        assert status == {"needs_setup": False, "registration_open": True}
+
+        second = client.post(
+            "/api/auth/register",
+            json={"agency_name": "South Studio", "name": "Mario", "email": "mario@sur.com", "password": "very-secure-key"},
+        )
+        assert second.status_code == 201
+    finally:
+        settings.allow_multi_agency = False
+
+
 def test_provider_key_is_stored_masked(authenticated_client: TestClient):
     saved = authenticated_client.put("/api/providers/openai", json={"api_key": "sk-super-secret-key"})
     assert saved.status_code == 200

--- a/apps/api/tests/test_flows.py
+++ b/apps/api/tests/test_flows.py
@@ -111,26 +111,23 @@ def test_single_agency_instance_closes_registration(client: TestClient):
     assert client.post("/api/auth/login", json={"email": "laura@norte.com", "password": "very-secure-key"}).status_code == 200
 
 
-def test_multi_agency_flag_keeps_registration_open(client: TestClient):
-    settings = get_settings()
-    settings.allow_multi_agency = True
-    try:
-        first = client.post(
-            "/api/auth/register",
-            json={"agency_name": "North Studio", "name": "Laura", "email": "laura@norte.com", "password": "very-secure-key"},
-        )
-        assert first.status_code == 201
+def test_multi_agency_flag_keeps_registration_open(client: TestClient, monkeypatch):
+    monkeypatch.setattr(get_settings(), "allow_multi_agency", True)
 
-        status = client.get("/api/auth/status").json()
-        assert status == {"needs_setup": False, "registration_open": True}
+    first = client.post(
+        "/api/auth/register",
+        json={"agency_name": "North Studio", "name": "Laura", "email": "laura@norte.com", "password": "very-secure-key"},
+    )
+    assert first.status_code == 201
 
-        second = client.post(
-            "/api/auth/register",
-            json={"agency_name": "South Studio", "name": "Mario", "email": "mario@sur.com", "password": "very-secure-key"},
-        )
-        assert second.status_code == 201
-    finally:
-        settings.allow_multi_agency = False
+    status = client.get("/api/auth/status").json()
+    assert status == {"needs_setup": False, "registration_open": True}
+
+    second = client.post(
+        "/api/auth/register",
+        json={"agency_name": "South Studio", "name": "Mario", "email": "mario@sur.com", "password": "very-secure-key"},
+    )
+    assert second.status_code == 201
 
 
 def test_provider_key_is_stored_masked(authenticated_client: TestClient):

--- a/apps/api/tests/test_whatsapp_cloud.py
+++ b/apps/api/tests/test_whatsapp_cloud.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+from app.config import get_settings
 from app.routers import whatsapp_cloud as whatsapp_cloud_router
 from app.routers import whatsapp_cloud_webhook as webhook_router
 from app.services import ai as ai_service
@@ -107,11 +108,18 @@ def test_configure_channel_hides_secrets(authenticated_client: TestClient):
     assert resaved["phone_number_id"] == "222"
     assert resaved["webhook_verify_token"] == channel["webhook_verify_token"]
 
-    # Another agency cannot see the channel.
-    client.post(
-        "/api/auth/register",
-        json={"agency_name": "Other", "name": "Eve", "email": "eve@other.com", "password": "another-password"},
-    )
+    # Another agency cannot see the channel. Registration closes after the
+    # first agency, so allow a second one just for this check.
+    settings = get_settings()
+    settings.allow_multi_agency = True
+    try:
+        other = client.post(
+            "/api/auth/register",
+            json={"agency_name": "Other", "name": "Eve", "email": "eve@other.com", "password": "another-password"},
+        )
+        assert other.status_code == 201
+    finally:
+        settings.allow_multi_agency = False
     assert client.get(f"/api/whatsapp-cloud/channels/{customer['id']}").status_code == 404
 
 

--- a/apps/api/tests/test_whatsapp_cloud.py
+++ b/apps/api/tests/test_whatsapp_cloud.py
@@ -85,7 +85,7 @@ def _setup_channel(client: TestClient, *, image_enabled: bool = False) -> tuple[
     return customer, agent, channel
 
 
-def test_configure_channel_hides_secrets(authenticated_client: TestClient):
+def test_configure_channel_hides_secrets(authenticated_client: TestClient, monkeypatch):
     client = authenticated_client
     customer, agent, channel = _setup_channel(client)
     assert channel["has_access_token"] is True
@@ -110,16 +110,12 @@ def test_configure_channel_hides_secrets(authenticated_client: TestClient):
 
     # Another agency cannot see the channel. Registration closes after the
     # first agency, so allow a second one just for this check.
-    settings = get_settings()
-    settings.allow_multi_agency = True
-    try:
-        other = client.post(
-            "/api/auth/register",
-            json={"agency_name": "Other", "name": "Eve", "email": "eve@other.com", "password": "another-password"},
-        )
-        assert other.status_code == 201
-    finally:
-        settings.allow_multi_agency = False
+    monkeypatch.setattr(get_settings(), "allow_multi_agency", True)
+    other = client.post(
+        "/api/auth/register",
+        json={"agency_name": "Other", "name": "Eve", "email": "eve@other.com", "password": "another-password"},
+    )
+    assert other.status_code == 201
     assert client.get(f"/api/whatsapp-cloud/channels/{customer['id']}").status_code == 404
 
 

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Bot, Building2, LoaderCircle, MessageSquareText, ShieldCheck } from "lucide-react";
 import { api, messageFrom } from "@/lib/api";
 import { useT } from "@/lib/i18n";
 import { Alert } from "@/components/ui";
+
+type AuthStatus = { needs_setup: boolean; registration_open: boolean };
 
 export default function LoginPage() {
   const t = useT();
@@ -13,6 +15,20 @@ export default function LoginPage() {
   const [mode, setMode] = useState<"login" | "register">("login");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
+
+  useEffect(() => {
+    api<AuthStatus>("/auth/status")
+      .then((status) => {
+        setAuthStatus(status);
+        if (status.needs_setup) setMode("register");
+      })
+      .catch(() => setAuthStatus({ needs_setup: false, registration_open: true }));
+  }, []);
+
+  // First run (no agency yet) goes straight to setup; afterwards the register
+  // tab only exists on multi-agency instances.
+  const showTabs = Boolean(authStatus && !authStatus.needs_setup && authStatus.registration_open);
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -56,10 +72,10 @@ export default function LoginPage() {
             <span className="access-card-label"><ShieldCheck size={15} /> {t("auth.cardLabel")}</span>
             <h2>{mode === "register" ? t("auth.cardTitleRegister") : t("auth.cardTitleLogin")}</h2>
             <p>{mode === "register" ? t("auth.cardSubtitleRegister") : t("auth.cardSubtitleLogin")}</p>
-            <div className="auth-tabs">
+            {showTabs && <div className="auth-tabs">
               <button type="button" className={mode === "login" ? "active" : ""} onClick={() => { setMode("login"); setError(""); }}>{t("auth.tabLogin")}</button>
               <button type="button" className={mode === "register" ? "active" : ""} onClick={() => { setMode("register"); setError(""); }}>{t("auth.tabRegister2")}</button>
-            </div>
+            </div>}
             <form onSubmit={submit} className="access-form">
               {mode === "register" && <>
                 <label>{t("auth.agencyName")}<input name="agency_name" required minLength={2} placeholder={t("auth.agencyNamePlaceholder")} /></label>


### PR DESCRIPTION
## Summary

- Self-hosted instances are single-agency by default: the first registration creates the owner agency and closes public sign-up.
- Adds public `GET /api/auth/status` so the login page shows first-run setup on an empty DB and hides the register tab afterwards.
- Deployments that need many agencies can opt out with `ALLOW_MULTI_AGENCY=true`.

## Test plan

- [ ] Fresh install (empty DB): login page shows agency setup only
- [ ] After creating the first agency: only Sign in is shown
- [ ] Existing login/logout still works