### PR TITLE
Correct the model catalog docstring

### DIFF
--- a/apps/api/app/services/model_catalog.py
+++ b/apps/api/app/services/model_catalog.py
@@ -3,7 +3,7 @@
 Each model declares its context window, capabilities (tools/vision) and price
 per 1k tokens. This metadata powers:
 - the model picker and token counter in the agent creation wizard,
-- cost estimation and per-model markup (billing).
+- the per-model cost figures the catalog API exposes to clients.
 
 IDs are kept in sync with `apps/web/lib/providers.ts` (same identifiers per
 provider). Keep both in sync when adding models.


### PR DESCRIPTION
The second bullet in the module docstring named a consumer this service does not have.

The price metadata is exposed through the catalog API (`input_price_per_1k` / `output_price_per_1k` in `schemas.py`); that is what it powers in this repo. Docstring only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)