### PR TITLE
Feat/reply debounce and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ WHATSAPP_BRIDGE_URL=http://localhost:3101
 WHATSAPP_BRIDGE_PORT=3101
 WHATSAPP_BRIDGE_TOKEN=generate-a-long-random-token-for-the-bridge
 
+# Quiet window (seconds) before the AI answers WhatsApp messages: rapid-fire
+# visitor messages are batched into a single reply. Set to 0 to answer every
+# message immediately.
+# REPLY_DEBOUNCE_SECONDS=8
+
 # WhatsApp Cloud API (official Meta API). Channel credentials are configured
 # per client in the UI; this only overrides the Graph API root (e.g. to pin a
 # version or point at a mock in tests).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ bundles ffmpeg for voice-note transcoding.
 
 ### Added
 
+- Connection guides under `docs/connections/`: a step-by-step WhatsApp
+  Business Cloud API setup guide (Meta app, phone number, permanent access
+  token, app secret, webhook, go-live and troubleshooting), in English and
+  Spanish, linked from the README.
 - Mobile app for the client of an agency (`apps/mobile`, Expo/React Native, iOS
   and Android). Sign in with a server address plus the portal credentials the
   agency issued, and the business gets its conversations on a phone: read, take

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ bundles ffmpeg for voice-note transcoding.
 
 ### Added
 
+- Debounced WhatsApp replies: instead of answering every message the moment it
+  arrives, the assistant now waits for a quiet window (8 seconds by default,
+  `REPLY_DEBOUNCE_SECONDS`) that restarts with each new visitor message, then
+  answers the whole burst with a single reply — the way a person reads a run of
+  messages before responding. Applies to both WhatsApp channels (Baileys bridge
+  and Cloud API); set the window to `0` to restore the immediate
+  one-reply-per-message behaviour. No schema change.
 - Connection guides under `docs/connections/`: a step-by-step WhatsApp
   Business Cloud API setup guide (Meta app, phone number, permanent access
   token, app secret, webhook, go-live and troubleshooting), in English and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Everything is agency-scoped: `Agency → Users, Clients, AIConnections`; `Client
 
 ### WhatsApp flow
 
-The bridge (`apps/whatsapp/src/manager.ts`) holds live Baileys sessions and is stateful — encrypted session/auth state lives in PostgreSQL (via the backend), and the bridge reloads enabled sessions on startup. Incoming messages: bridge → `POST /api/whatsapp/channels/{channel_id}/inbound` on the backend → AI reply sent back through the bridge. Backend↔bridge calls authenticate with `WHATSAPP_BRIDGE_TOKEN`. Conversations have a `mode` field: switching to `"human"` pauses the AI so an operator answers from the portal.
+The bridge (`apps/whatsapp/src/manager.ts`) holds live Baileys sessions and is stateful — encrypted session/auth state lives in PostgreSQL (via the backend), and the bridge reloads enabled sessions on startup. Incoming messages: bridge → `POST /api/whatsapp/channels/{channel_id}/inbound` on the backend → AI reply sent back through the bridge. Replies are debounced (`REPLY_DEBOUNCE_SECONDS`, default 8s): the shared pipeline in `app/services/whatsapp_inbound.py` waits for a quiet window that restarts on each new visitor message, then answers the whole burst with one reply delivered via `send_channel_message()`; with the window at 0 the reply returns synchronously in the inbound response instead. Backend↔bridge calls authenticate with `WHATSAPP_BRIDGE_TOKEN`. Conversations have a `mode` field: switching to `"human"` pauses the AI so an operator answers from the portal.
 
 ### Frontend
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Full documentation lives at **[openlivery.com/docs](https://openlivery.com/docs)
 | [Self-hosting](https://openlivery.com/docs/self-hosting) | Deploy to a server, back up, upgrade and troubleshoot |
 | [Contributing](https://openlivery.com/docs/contributing) | Run the project locally, tests and conventions |
 | [Push notifications](docs/push-notifications.md) | Optional, provider-agnostic notifications for the mobile app |
+| [WhatsApp Cloud API](docs/connections/whatsapp-cloud-api.md) | Connect a number with the official Meta API, end to end ([en español](docs/connections/whatsapp-cloud-api.es.md)) |
 
 ## Features
 

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -38,6 +38,10 @@ class Settings(BaseSettings):
     # Meta Graph API root used by the WhatsApp Cloud API channel; override to
     # point at a mock server in tests.
     meta_graph_base_url: str = "https://graph.facebook.com/v23.0"
+    # Quiet window before the AI answers a WhatsApp message: while new visitor
+    # messages keep arriving the timer restarts, and the whole burst is answered
+    # with a single reply. 0 restores the immediate one-reply-per-message flow.
+    reply_debounce_seconds: float = 8.0
 
     # Push notifications for the mobile app. "none" (the default) sends nothing
     # and needs no account with anyone; "webhook" POSTs each event to

--- a/apps/api/app/services/whatsapp_inbound.py
+++ b/apps/api/app/services/whatsapp_inbound.py
@@ -6,6 +6,7 @@ store the visitor message, and produce the AI reply unless a human operator has
 taken over. The caller is responsible for actually delivering the reply.
 """
 
+import asyncio
 import uuid
 from dataclasses import dataclass
 
@@ -13,6 +14,8 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
+from ..config import get_settings
+from ..database import SessionLocal
 from ..models import Agent, Conversation, Message, now_utc
 from .attachments import llm_text, store_attachment
 from .knowledge import build_system_prompt, retrieve_knowledge
@@ -21,6 +24,7 @@ from .notifications import notify_needs_human
 from .providers import resolve_agent_credentials, resolve_provider_credentials
 from .tools import run_completion
 from .usage import record_usage
+from .whatsapp import send_channel_message
 
 
 @dataclass
@@ -167,6 +171,19 @@ async def process_inbound(
         await notify_needs_human(db, conversation, display_content or llm_content)
         return InboundResult(accepted=True, conversation_id=conversation.id, mode="human")
 
+    if get_settings().reply_debounce_seconds > 0:
+        schedule_debounced_reply(conversation.id)
+        return InboundResult(accepted=True, conversation_id=conversation.id, mode="ai")
+
+    return await _reply_with_ai(db, channel, conversation, llm_content)
+
+
+async def _reply_with_ai(db: Session, channel, conversation: Conversation, retrieval_query: str) -> InboundResult:
+    """Generate and store the AI reply for the conversation's current history.
+
+    ``retrieval_query`` drives knowledge retrieval: the triggering message's
+    text on the synchronous path, or the whole visitor burst when debounced.
+    """
     agent = channel.agent
     credentials = resolve_agent_credentials(db, agent)
     if not agent.is_active or not credentials or not agent.model.strip():
@@ -175,7 +192,7 @@ async def process_inbound(
         db.commit()
         return InboundResult(accepted=True, conversation_id=conversation.id, mode="ai")
 
-    knowledge = await retrieve_knowledge(db, agent, llm_content)
+    knowledge = await retrieve_knowledge(db, agent, retrieval_query)
     db.refresh(conversation)
     history = db.scalars(
         select(Message)
@@ -226,3 +243,82 @@ async def process_inbound(
         mode="ai",
         outbound_message_id=outbound.id,
     )
+
+
+_pending_replies: dict[uuid.UUID, "asyncio.Task[None]"] = {}
+
+
+def schedule_debounced_reply(conversation_id: uuid.UUID) -> None:
+    """(Re)start the conversation's quiet-window timer.
+
+    Every inbound message cancels the previous timer, so the reply fires only
+    once the window passes with no new visitor message, answering the whole
+    burst as a single reply built from the stored history. Timers are
+    in-process; a DB re-check when the timer fires keeps a stale one harmless.
+    """
+    previous = _pending_replies.pop(conversation_id, None)
+    if previous is not None and not previous.done():
+        previous.cancel()
+    task = asyncio.get_running_loop().create_task(_debounced_reply(conversation_id))
+    _pending_replies[conversation_id] = task
+
+    def _cleanup(finished: "asyncio.Task[None]") -> None:
+        if _pending_replies.get(conversation_id) is finished:
+            _pending_replies.pop(conversation_id, None)
+
+    task.add_done_callback(_cleanup)
+
+
+async def _debounced_reply(conversation_id: uuid.UUID) -> None:
+    await asyncio.sleep(get_settings().reply_debounce_seconds)
+    db = SessionLocal()
+    try:
+        conversation = db.get(Conversation, conversation_id)
+        if not conversation or conversation.mode == "human":
+            return
+        channel = conversation.whatsapp_channel or conversation.whatsapp_cloud_channel
+        if not channel:
+            return
+        last = db.scalar(
+            select(Message)
+            .where(Message.conversation_id == conversation_id)
+            .order_by(Message.created_at.desc())
+            .limit(1)
+        )
+        if not last or last.role != "user":
+            # A newer timer, another worker, or an operator already answered.
+            return
+        history = db.scalars(
+            select(Message)
+            .where(Message.conversation_id == conversation_id)
+            .order_by(Message.created_at.desc())
+            .limit(channel.agent.memory_limit)
+        ).all()
+        burst: list[str] = []
+        for item in history:
+            if item.role != "user":
+                break
+            burst.append(llm_text(item))
+        try:
+            result = await _reply_with_ai(db, channel, conversation, "\n".join(reversed(burst)))
+        except Exception as exc:
+            channel.last_error = f"Message received, but the agent could not reply: {str(exc)[:400]}"
+            channel.updated_at = now_utc()
+            db.commit()
+            return
+        if not result.reply:
+            return
+        try:
+            external_id = await send_channel_message(db, conversation, result.reply)
+        except HTTPException as exc:
+            channel.last_error = f"The reply could not be sent: {exc.detail}"
+            channel.updated_at = now_utc()
+            db.commit()
+            return
+        if external_id and result.outbound_message_id:
+            outbound = db.get(Message, result.outbound_message_id)
+            if outbound:
+                outbound.external_message_id = external_id
+                db.commit()
+    finally:
+        db.close()

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -10,6 +10,7 @@ os.environ["DATABASE_URL"] = os.getenv(
     "postgresql+psycopg://openlivery:openlivery@localhost:5432/openlivery_test",
 )
 os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
+os.environ.setdefault("REPLY_DEBOUNCE_SECONDS", "0")
 
 from app.database import Base, get_db  # noqa: E402
 from app.main import app  # noqa: E402

--- a/apps/api/tests/test_reply_debounce.py
+++ b/apps/api/tests/test_reply_debounce.py
@@ -1,0 +1,148 @@
+"""The debounced WhatsApp reply: a burst of visitor messages gets one answer.
+
+These tests drive the service layer directly (not the HTTP endpoint) so the
+debounce timers run inside a single asyncio loop the test controls.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import SessionLocal
+from app.models import Conversation, Message, WhatsAppChannel
+from app.services import whatsapp_inbound as inbound_service
+from app.services.ai import Completion
+
+
+def _setup_channel(client: TestClient) -> None:
+    customer = client.post(
+        "/api/clients",
+        json={
+            "name": "Sol Store",
+            "industry": "Retail",
+            "description": "",
+            "general_context": "Open Monday through Saturday.",
+            "is_active": True,
+        },
+    ).json()
+    client.put("/api/providers/openai", json={"api_key": "secret"})
+    agent = client.post(
+        "/api/agents",
+        json={
+            "client_id": customer["id"],
+            "provider": "openai",
+            "model": "gpt-4.1-mini",
+            "name": "Sol Advisor",
+            "description": "",
+            "instructions": "Help the customers.",
+            "personality": "Friendly",
+            "is_active": True,
+        },
+    ).json()
+    assert client.put(
+        f"/api/whatsapp/channels/{customer['id']}", json={"agent_id": agent["id"]}
+    ).status_code == 200
+
+
+def _inbound(external_message_id: str, text: str) -> inbound_service.InboundMessage:
+    return inbound_service.InboundMessage(
+        external_message_id=external_message_id,
+        external_chat_id="573001112233@s.whatsapp.net",
+        sender_name="Cliente",
+        text=text,
+    )
+
+
+async def _process(db, channel, message: inbound_service.InboundMessage):
+    return await inbound_service.process_inbound(
+        db,
+        channel,
+        message,
+        conversation_channel="whatsapp",
+        channel_fk_field="whatsapp_channel_id",
+    )
+
+
+def test_burst_is_answered_with_a_single_reply(authenticated_client: TestClient, monkeypatch):
+    _setup_channel(authenticated_client)
+    monkeypatch.setattr(get_settings(), "reply_debounce_seconds", 0.15)
+    completion = AsyncMock(return_value=Completion(text="One combined answer"))
+    monkeypatch.setattr(inbound_service, "run_completion", completion)
+    send = AsyncMock(return_value="wamid-out-1")
+    monkeypatch.setattr(inbound_service, "send_channel_message", send)
+
+    db = SessionLocal()
+    try:
+        channel = db.scalar(select(WhatsAppChannel))
+
+        async def scenario():
+            first = await _process(db, channel, _inbound("wa-1", "domi"))
+            assert first.accepted and first.reply is None
+            second = await _process(db, channel, _inbound("wa-2", "gracias"))
+            assert second.accepted and second.reply is None
+            await asyncio.sleep(0.5)
+
+        asyncio.run(scenario())
+
+        assert completion.await_count == 1
+        prompt_messages = completion.await_args.args[4]
+        user_turns = [m["content"] for m in prompt_messages if m["role"] == "user"]
+        assert user_turns == ["domi", "gracias"]
+
+        send.assert_awaited_once()
+        assert send.await_args.args[2] == "One combined answer"
+
+        replies = db.scalars(select(Message).where(Message.role == "assistant")).all()
+        assert len(replies) == 1
+        assert replies[0].content == "One combined answer"
+        assert replies[0].external_message_id == "wamid-out-1"
+    finally:
+        db.close()
+
+
+def test_no_reply_when_operator_takes_over_during_the_window(
+    authenticated_client: TestClient, monkeypatch
+):
+    _setup_channel(authenticated_client)
+    monkeypatch.setattr(get_settings(), "reply_debounce_seconds", 0.15)
+    completion = AsyncMock(return_value=Completion(text="Should never be sent"))
+    monkeypatch.setattr(inbound_service, "run_completion", completion)
+    send = AsyncMock(return_value="wamid-out-1")
+    monkeypatch.setattr(inbound_service, "send_channel_message", send)
+
+    db = SessionLocal()
+    try:
+        channel = db.scalar(select(WhatsAppChannel))
+
+        async def scenario():
+            await _process(db, channel, _inbound("wa-1", "quiero hablar con alguien"))
+            conversation = db.scalar(select(Conversation))
+            conversation.mode = "human"
+            db.commit()
+            await asyncio.sleep(0.5)
+
+        asyncio.run(scenario())
+
+        completion.assert_not_awaited()
+        send.assert_not_awaited()
+    finally:
+        db.close()
+
+
+def test_zero_window_keeps_the_immediate_reply(authenticated_client: TestClient, monkeypatch):
+    _setup_channel(authenticated_client)
+    monkeypatch.setattr(get_settings(), "reply_debounce_seconds", 0)
+    completion = AsyncMock(return_value=Completion(text="Immediate answer"))
+    monkeypatch.setattr(inbound_service, "run_completion", completion)
+
+    db = SessionLocal()
+    try:
+        channel = db.scalar(select(WhatsAppChannel))
+        result = asyncio.run(_process(db, channel, _inbound("wa-1", "hola")))
+        assert result.reply == "Immediate answer"
+        assert result.outbound_message_id is not None
+    finally:
+        db.close()

--- a/docs/connections/whatsapp-cloud-api.es.md
+++ b/docs/connections/whatsapp-cloud-api.es.md
@@ -1,0 +1,147 @@
+# Conectar la API de WhatsApp Business Cloud
+
+> Read in English: [whatsapp-cloud-api.md](whatsapp-cloud-api.md)
+
+Esta guía explica cómo conectar el número de WhatsApp de un cliente a
+OpenLivery usando la **API oficial de WhatsApp Business Cloud** (alojada por
+Meta): desde crear la app en Meta hasta pegar las credenciales en OpenLivery
+y salir a producción. Es independiente del canal WhatsApp QR — un cliente
+puede tener ambos conectados en números distintos.
+
+Al final habrás ingresado cuatro valores en OpenLivery:
+
+| Valor | De dónde sale |
+| --- | --- |
+| **ID del número de teléfono** | Portal de desarrolladores de Meta → WhatsApp → API Setup |
+| **ID de la cuenta de WhatsApp Business** (opcional) | La misma pantalla del ID del número |
+| **Token de acceso permanente** | Un *usuario del sistema* de Business Suite (paso 4) |
+| **Secreto de la app** | App Dashboard → App settings → Basic |
+
+## 1. Requisitos previos
+
+Antes de la configuración técnica, asegúrate de tener:
+
+- Un **portafolio comercial de Meta** (antes Business Manager) en buen estado:
+  - **Verificación del negocio** completada — revísala en
+    **Settings > Business Info > Verification Status**.
+  - Un **método de pago** vinculado a la cuenta de WhatsApp dentro de
+    Business Suite para cubrir los costos de conversación.
+- Un número de teléfono que pueda recibir un SMS o una llamada de
+  verificación y que **no** esté registrado actualmente en las apps de
+  WhatsApp/WhatsApp Business.
+- Una instancia de OpenLivery accesible por **HTTPS público** (Meta solo
+  entrega webhooks a URLs HTTPS), con el cliente creado y un agente asignado.
+
+## 2. Crear la app de Meta
+
+1. Entra al portal de [Meta for Developers](https://developers.facebook.com/).
+2. Haz clic en **Create App**.
+3. Como tipo de app elige **Other** y luego **Business**.
+4. Dentro del App Dashboard busca el producto **WhatsApp** y haz clic en
+   **Set Up**.
+5. Cuando lo pida, vincula la app con tu **portafolio comercial verificado**.
+
+## 3. Configurar el número de WhatsApp
+
+1. En el portal de desarrolladores ve a **WhatsApp > API Setup**.
+2. **Add phone number** y sigue los pasos para agregar el número del negocio.
+3. Elige un **nombre visible** que represente claramente la marca (por
+   ejemplo, "Di Pizza Gourmet").
+   - Meta revisa este nombre. Si lo rechaza, usa **Edit Display Name** para
+     dar uno más específico y menos genérico.
+4. Completa la **verificación por SMS o llamada** del número.
+5. Copia el **Phone number ID** que aparece en esta pantalla — es el que
+   pegarás en OpenLivery. El **ID de la cuenta de WhatsApp Business**
+   (WABA ID) aparece en la misma pantalla y es opcional en OpenLivery.
+
+## 4. Generar el token de acceso permanente
+
+El token que muestra la pantalla de API Setup caduca en 24 horas. Para una
+conexión permanente, créalo con un usuario del sistema:
+
+1. Ve a **Meta Business Suite > Settings > Users > System Users**.
+2. Selecciona un **usuario del sistema administrador** existente, o crea uno.
+3. Haz clic en **Assign Assets**, elige **Apps**, selecciona tu app de
+   WhatsApp y habilita **Full Control (Manage App)**.
+4. Haz clic en **Generate New Token**, selecciona la app y marca estos
+   permisos:
+   - `whatsapp_business_messaging`
+   - `whatsapp_business_management`
+5. **Copia el token de inmediato y guárdalo en un lugar seguro** — Meta no lo
+   volverá a mostrar. Este es el **token de acceso permanente** para
+   OpenLivery.
+
+## 5. Obtener el secreto de la app
+
+1. En el App Dashboard ve a **App settings > Basic**.
+2. Haz clic en **Show** junto a **App secret** y cópialo.
+
+OpenLivery usa el secreto de la app para validar la firma HMAC de cada
+webhook que envía Meta, de modo que las solicitudes que no vienen realmente
+de Meta se rechazan.
+
+## 6. Ingresar las credenciales en OpenLivery
+
+1. En OpenLivery abre **Clientes**, elige el cliente y en su pestaña de
+   **Canales** abre la tarjeta **WhatsApp API** (también accesible desde la
+   página **Canales**).
+2. Selecciona el **agente** que responderá este número.
+3. Completa:
+   - **ID del número de teléfono** (del paso 3)
+   - **ID de la cuenta de WhatsApp Business** — opcional
+   - **Token de acceso permanente** (del paso 4)
+   - **Secreto de la app** (del paso 5)
+4. Haz clic en **Guardar credenciales**. El token y el secreto se cifran en
+   reposo y son de solo escritura: la API nunca los devuelve, y dejarlos en
+   blanco en un guardado posterior conserva los valores almacenados.
+
+## 7. Registrar el webhook
+
+En la misma página del canal, OpenLivery muestra una **URL de callback** y un
+**token de verificación** con botones de copiado:
+
+1. En el portal de desarrolladores de Meta ve a **WhatsApp > Configuration**.
+2. Pega la **URL de callback** y el **token de verificación**, y guarda. Meta
+   llama la URL una vez para verificar el handshake — debe funcionar antes de
+   poder continuar.
+3. En **Webhooks**, haz clic en **Manage** y suscríbete al campo
+   **`messages`**.
+
+> La URL de callback se construye con la dirección pública de la instancia,
+> así que la instancia debe ser accesible por HTTPS en esa URL. Si el
+> handshake falla, revisa la sección de solución de problemas.
+
+## 8. Conectar y salir a producción
+
+1. De vuelta en OpenLivery haz clic en **Conectar y verificar**. OpenLivery
+   valida las credenciales contra la Graph API y captura el número y su
+   nombre verificado; el estado del canal cambia a **conectado**.
+2. En el portal de desarrolladores cambia el **App Mode** de **Development**
+   a **Live** (barra superior) para permitir el tráfico real de clientes.
+3. Envía un mensaje de WhatsApp al número: el agente asignado debería
+   responder, y la conversación aparece en el Inbox de OpenLivery.
+
+## 9. Solución de problemas
+
+- **Error de autorización** — normalmente un token caducado o permisos
+  faltantes (`whatsapp_business_messaging`). Genera un nuevo token permanente
+  (paso 4) y guárdalo de nuevo en OpenLivery.
+- **Nombre visible pendiente o rechazado** — asegúrate de que el nombre
+  visible coincida con el nombre legal del negocio o con la marca del sitio
+  web.
+- **Pago requerido** — el método de pago debe estar asignado específicamente
+  a la **cuenta de WhatsApp** en Business Suite, no solo a la cuenta
+  publicitaria general.
+- **La verificación del webhook falla** — el token de verificación pegado en
+  Meta debe coincidir exactamente con el que muestra OpenLivery, y la URL de
+  callback debe ser accesible desde internet por HTTPS. En instancias
+  self-hosted, revisa que `FRONTEND_URL` apunte a la dirección pública de la
+  app.
+- **No llegan mensajes** — confirma la suscripción al campo de webhook
+  **`messages`** (paso 7) y que la app esté en modo **Live**; en modo
+  Development Meta solo entrega tráfico de números de prueba. La tarjeta del
+  canal en OpenLivery muestra el último error del webhook, si lo hay.
+- **Llegan mensajes pero el agente no responde** — el canal está conectado
+  pero el agente asignado puede estar inactivo o sin la API key de su
+  proveedor; la tarjeta del canal muestra la razón exacta en **último
+  error**.

--- a/docs/connections/whatsapp-cloud-api.md
+++ b/docs/connections/whatsapp-cloud-api.md
@@ -1,0 +1,139 @@
+# Connecting the WhatsApp Business Cloud API
+
+> Leer en español: [whatsapp-cloud-api.es.md](whatsapp-cloud-api.es.md)
+
+This guide walks through connecting a client's WhatsApp number to OpenLivery
+using the official **WhatsApp Business Cloud API** (hosted by Meta): from
+creating the Meta app to pasting the credentials into OpenLivery and going
+live. It is independent from the WhatsApp QR channel — a client can have both
+connected on different numbers.
+
+At the end you will have entered four values into OpenLivery:
+
+| Value | Where it comes from |
+| --- | --- |
+| **Phone number ID** | Meta Developer Portal → WhatsApp → API Setup |
+| **WhatsApp Business account ID** (optional) | Same screen as the phone number ID |
+| **Permanent access token** | A Business Suite *system user* (step 4) |
+| **App secret** | App Dashboard → App settings → Basic |
+
+## 1. Prerequisites
+
+Before the technical setup, make sure you have:
+
+- A **Meta Business Portfolio** (formerly Business Manager) in good standing:
+  - **Business verification** completed — check it under
+    **Settings > Business Info > Verification Status**.
+  - A **payment method** linked to the WhatsApp account inside Business Suite
+    to cover conversation costs.
+- A phone number that can receive an SMS or voice verification call and is
+  **not** currently registered on the WhatsApp/WhatsApp Business apps.
+- An OpenLivery instance reachable over **public HTTPS** (Meta only delivers
+  webhooks to HTTPS URLs), with the client created and an agent assigned to it.
+
+## 2. Create the Meta app
+
+1. Go to the [Meta for Developers](https://developers.facebook.com/) portal.
+2. Click **Create App**.
+3. As the app type choose **Other**, then **Business**.
+4. Inside the App Dashboard find the **WhatsApp** product and click **Set Up**.
+5. When asked, link the app to your **verified Business Portfolio**.
+
+## 3. Configure the WhatsApp number
+
+1. In the Developer Portal go to **WhatsApp > API Setup**.
+2. **Add phone number** and follow the prompts to add the business number.
+3. Choose a **display name** that clearly represents the brand (for example,
+   "Di Pizza Gourmet").
+   - Meta reviews this name. If it is rejected, use **Edit Display Name** to
+     provide a more specific, non-generic one.
+4. Complete the **SMS or voice verification** for the number.
+5. Copy the **Phone number ID** shown on this screen — you will paste it into
+   OpenLivery. The **WhatsApp Business account ID** (WABA ID) appears on the
+   same screen and is optional in OpenLivery.
+
+## 4. Generate a permanent access token
+
+The token shown on the API Setup screen expires in 24 hours. For a permanent
+connection, create one through a system user:
+
+1. Go to **Meta Business Suite > Settings > Users > System Users**.
+2. Select an existing **Admin system user**, or create one.
+3. Click **Assign Assets**, choose **Apps**, select your WhatsApp app and
+   enable **Full Control (Manage App)**.
+4. Click **Generate New Token**, select the app, and check these scopes:
+   - `whatsapp_business_messaging`
+   - `whatsapp_business_management`
+5. **Copy the token immediately and store it safely** — Meta will not show it
+   again. This is the **Permanent access token** for OpenLivery.
+
+## 5. Get the app secret
+
+1. In the App Dashboard go to **App settings > Basic**.
+2. Click **Show** next to **App secret** and copy it.
+
+OpenLivery uses the app secret to validate the HMAC signature of every
+webhook Meta sends, so requests that are not really from Meta are rejected.
+
+## 6. Enter the credentials in OpenLivery
+
+1. In OpenLivery open **Clients**, pick the client, and on its **Channels**
+   tab open the **WhatsApp API** card (also reachable from the **Channels**
+   page).
+2. Select the **agent** that will answer this number.
+3. Fill in:
+   - **Phone number ID** (from step 3)
+   - **WhatsApp Business account ID** — optional
+   - **Permanent access token** (from step 4)
+   - **App secret** (from step 5)
+4. Click **Save credentials**. The token and secret are encrypted at rest and
+   are write-only: the API never returns them, and leaving them blank on a
+   later save keeps the stored values.
+
+## 7. Register the webhook
+
+Still on the channel page, OpenLivery shows a **Callback URL** and a
+**Verify token** with copy buttons:
+
+1. In the Meta Developer Portal go to **WhatsApp > Configuration**.
+2. Paste the **Callback URL** and the **Verify token**, then save. Meta calls
+   the URL once to verify the handshake — it must succeed before you can
+   continue.
+3. Under **Webhooks**, click **Manage** and subscribe to the **`messages`**
+   field.
+
+> The callback URL is built from the instance's public address, so the
+> instance must be reachable over HTTPS at that URL. If the handshake fails,
+> see the troubleshooting section.
+
+## 8. Connect and go live
+
+1. Back in OpenLivery click **Connect and verify**. OpenLivery validates the
+   credentials against the Graph API and captures the number and its verified
+   name; the channel status changes to **connected**.
+2. In the Developer Portal switch the **App Mode** from **Development** to
+   **Live** (top bar) so real customer traffic can flow.
+3. Send a WhatsApp message to the number: the assigned agent should answer,
+   and the conversation appears in the OpenLivery Inbox.
+
+## 9. Troubleshooting
+
+- **Authorization error** — usually an expired token or missing permissions
+  (`whatsapp_business_messaging`). Generate a new permanent token (step 4)
+  and save it again in OpenLivery.
+- **Display name pending or rejected** — make sure the display name matches
+  the legal business name or the website branding.
+- **Payment required** — the payment method must be assigned specifically to
+  the **WhatsApp account** in Business Suite, not just to the general Ad
+  Account.
+- **Webhook verification fails** — the verify token pasted in Meta must match
+  the one OpenLivery shows exactly, and the callback URL must be reachable
+  from the internet over HTTPS. On self-hosted instances, check that
+  `FRONTEND_URL` points to the public address of the app.
+- **No messages arrive** — confirm the subscription to the **`messages`**
+  webhook field (step 7), and that the app is in **Live** mode; in
+  Development mode Meta only delivers traffic from test numbers. The channel
+  card in OpenLivery shows the last webhook error, if any.
+- **Messages arrive but the agent does not answer** — the channel is
+  connected but the assigned agent may be inactive or missing its provider
+  API key; the channel card shows the exact reason under **last error**.


### PR DESCRIPTION
Título:
Debounced WhatsApp replies and a Cloud API connection guide

Descripción:
## What's in this branch

### Debounced WhatsApp replies
Instead of answering every inbound message the moment it arrives, the assistant
now waits for a quiet window (`REPLY_DEBOUNCE_SECONDS`, default 8s) that
restarts with each new visitor message, then answers the whole burst with a
single reply — the way a person reads a run of messages before responding. If a
customer sends 10 short lines, the bot answers once, not 10 times.

- Lives in the shared inbound pipeline (`app/services/whatsapp_inbound.py`), so
  it covers both WhatsApp channels: Baileys bridge (QR) and Cloud API.
- No Redis, no buffffers: the reply is built from the conversation history
  already stored in Postgres; the timer only defers and dedupes the trigger.
- The window re-checks state before firing: if an operator took the
  conversation over ("human" mode) or a newer message arrived, it stays quiet.
- Delivery reuses `send_channel_message()` (same path as operator replies), so
  the bridge needed no changes — it already tolerates an empty inbound reply.
- Config via env var only, no per-agent setting. `0` restores the old
  immediate one-reply-per-message behavior (tests run with `0` by default).
- No schema change, no endpoint contract change → no friction for downstream
  consumers of this repo (submodule bumps just inherit the behavior).

**Tests:** new `tests/test_reply_debounce.py` (burst → one combined reply with
both messages in the prompt; human takeover during the window → silence;
window at 0 → synchronous flow intact). Full suite passes: 58/58.

**Tried on a real number (WhatsApp QR):** 4 rapid messages → one reply ~8s
after the last one.

### WhatsApp Cloud API connection guide
New `docs/connections/` folder for channel connection guides, starting with a
step-by-step WhatsApp Business Cloud API walkthrough — Meta business
portfolio requirements, app creation, phone number and display-name review,
permanent access token via a system user, app secret, webhook registration,
go-live and troubleshooting — using the exact field labels the OpenLivery UI
shows. Available in English and Spanish, linked from the README.