### PR TITLE
Fix voice note delivery on the WhatsApp Cloud API

### DIFF
--- a/apps/api/app/routers/whatsapp_cloud_webhook.py
+++ b/apps/api/app/routers/whatsapp_cloud_webhook.py
@@ -9,6 +9,7 @@ payload is parsed only after the signature check passes.
 import hashlib
 import hmac
 import json
+import logging
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -24,6 +25,8 @@ from ..services.whatsapp_inbound import InboundMessage, process_inbound
 
 
 public_router = APIRouter(prefix="/public/whatsapp-cloud", tags=["WhatsApp Cloud public"])
+
+logger = logging.getLogger("openlivery.whatsapp_cloud")
 
 
 def _channel(db: Session, channel_id: uuid.UUID) -> WhatsAppCloudChannel:
@@ -105,6 +108,8 @@ async def receive_webhook(channel_id: uuid.UUID, request: Request, db: Session =
             if change.get("field") != "messages":
                 continue
             value = change.get("value") or {}
+            for status in value.get("statuses") or []:
+                _record_status(db, channel, status)
             contacts = {
                 contact.get("wa_id"): (contact.get("profile") or {}).get("name")
                 for contact in value.get("contacts") or []
@@ -115,6 +120,28 @@ async def receive_webhook(channel_id: uuid.UUID, request: Request, db: Session =
                     continue
                 await _handle_message(db, channel, inbound, raw_message, access_token)
     return {"status": "ok"}
+
+
+def _record_status(db: Session, channel: WhatsAppCloudChannel, status: dict) -> None:
+    """Surface outbound delivery failures reported by Meta. Every outbound
+    message gets sent/delivered/read receipts here; only failures matter —
+    without this, a message Meta accepted (wamid returned) could be dropped
+    at delivery with no trace of the reason anywhere."""
+    if status.get("status") != "failed":
+        return
+    parts = []
+    for error in status.get("errors") or []:
+        detail = (error.get("error_data") or {}).get("details") or error.get("message") or error.get("title") or ""
+        parts.append(f"{error.get('code')}: {detail}".strip(": "))
+    summary = "; ".join(parts) or "no error detail provided"
+    logger.warning(
+        "WhatsApp Cloud delivery failed for %s: %s",
+        status.get("id") or "unknown message",
+        summary,
+    )
+    channel.last_error = f"Meta could not deliver a message ({summary})"[:400]
+    channel.updated_at = now_utc()
+    db.commit()
 
 
 async def _handle_message(

--- a/apps/api/app/services/whatsapp.py
+++ b/apps/api/app/services/whatsapp.py
@@ -83,6 +83,11 @@ async def send_channel_media(
         # WhatsApp only plays ogg/opus voice notes; browsers record webm/mp4.
         data, mime = await to_whatsapp_voice(data, mime)
         seconds = await audio_duration_seconds(data)
+        if mime == "audio/ogg":
+            # The filename must match the transcoded bytes: Meta classifies the
+            # upload by extension, and an ogg named .mp4/.webm comes out as
+            # application/octet-stream and fails delivery (error 131053).
+            filename = "voice-note.ogg"
     if conversation.channel == "whatsapp":
         if not conversation.whatsapp_channel_id or not conversation.external_chat_id:
             raise HTTPException(status_code=409, detail="This conversation does not have a valid WhatsApp destination")

--- a/apps/api/tests/test_whatsapp_cloud.py
+++ b/apps/api/tests/test_whatsapp_cloud.py
@@ -1,6 +1,8 @@
+import asyncio
 import hashlib
 import hmac
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from fastapi import HTTPException
@@ -226,6 +228,82 @@ def test_webhook_ignores_statuses_and_unsupported_types(authenticated_client: Te
     sticker = _webhook_payload([{"from": "5730011", "id": "wamid.stk", "type": "sticker", "sticker": {"id": "1"}}])
     assert _post_signed(client, channel["id"], sticker).status_code == 200
     assert fake_completion.await_count == 0
+
+
+def test_webhook_failed_status_surfaces_delivery_error(authenticated_client: TestClient):
+    client = authenticated_client
+    customer, _agent, channel = _setup_channel(client)
+    payload = {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "statuses": [
+                                {
+                                    "id": "wamid.out-2",
+                                    "status": "failed",
+                                    "errors": [
+                                        {
+                                            "code": 131053,
+                                            "title": "Media upload error",
+                                            "error_data": {"details": "The audio is not a valid ogg/opus file."},
+                                        }
+                                    ],
+                                }
+                            ]
+                        },
+                    }
+                ]
+            }
+        ],
+    }
+    assert _post_signed(client, channel["id"], payload).status_code == 200
+    detail = client.get(f"/api/whatsapp-cloud/channels/{customer['id']}").json()
+    assert "131053" in (detail["last_error"] or "")
+    assert "ogg/opus" in detail["last_error"]
+
+
+def test_transcoded_voice_note_uploads_with_ogg_filename(monkeypatch):
+    captured = {}
+
+    async def fake_voice(data, mime):
+        return b"OggS-transcoded", "audio/ogg"
+
+    async def fake_duration(data):
+        return 3
+
+    async def fake_upload(token, phone_number_id, data, mime, filename):
+        captured["mime"] = mime
+        captured["filename"] = filename
+        return "media-1"
+
+    async def fake_send(token, phone_number_id, to, kind, media_id, caption="", filename=None):
+        return "wamid.audio-out"
+
+    monkeypatch.setattr(whatsapp_service, "to_whatsapp_voice", fake_voice)
+    monkeypatch.setattr(whatsapp_service, "audio_duration_seconds", fake_duration)
+    monkeypatch.setattr(whatsapp_service, "upload_media", fake_upload)
+    monkeypatch.setattr(whatsapp_service, "send_media", fake_send)
+    monkeypatch.setattr(whatsapp_service, "decrypt_secret", lambda value: "token")
+
+    channel = SimpleNamespace(encrypted_access_token="enc", phone_number_id="111")
+    conversation = SimpleNamespace(
+        channel="whatsapp_cloud", whatsapp_cloud_channel_id="ch-1", external_chat_id="573001"
+    )
+    db = SimpleNamespace(get=lambda model, key: channel)
+
+    wamid = asyncio.run(
+        whatsapp_service.send_channel_media(
+            db, conversation, kind="audio", data=b"mp4-bytes", mime="audio/mp4", filename="voice-note.mp4"
+        )
+    )
+    assert wamid == "wamid.audio-out"
+    # Meta classifies uploads by extension: the name must match the ogg bytes.
+    assert captured["filename"] == "voice-note.ogg"
+    assert captured["mime"] == "audio/ogg"
 
 
 def test_webhook_human_mode_skips_ai(authenticated_client: TestClient, monkeypatch):


### PR DESCRIPTION
## Problem
Voice notes sent from the portal reached Meta (a wamid came back) but were never delivered to the end user. The capture of Meta's statuses webhook showed error 131053: the file was uploaded declared as ogg/opus but Meta classified it as application/octet-stream.

## Cause
The portal records `voice-note.mp4` (Safari); the backend transcodes the bytes to valid ogg/opus but uploaded them under the original `.mp4` name, and Meta classifies uploads by extension. The failure was invisible because the webhook discarded Meta's `statuses` callbacks unread.

## Changes
- Upload transcoded voice notes as `voice-note.ogg` so the name matches the bytes.
- Record `failed` statuses from the webhook: log a warning and surface the error in the channel's `last_error`.
- Tests for both behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)