### PR TITLE
Fix WhatsApp voice note delivery (error 131053)

### DIFF
--- a/apps/api/app/routers/whatsapp_cloud_webhook.py
+++ b/apps/api/app/routers/whatsapp_cloud_webhook.py
@@ -127,7 +127,16 @@ def _record_status(db: Session, channel: WhatsAppCloudChannel, status: dict) -> 
     message gets sent/delivered/read receipts here; only failures matter —
     without this, a message Meta accepted (wamid returned) could be dropped
     at delivery with no trace of the reason anywhere."""
-    if status.get("status") != "failed":
+    state = status.get("status")
+    if state in ("sent", "delivered", "read"):
+        # A delivery error is transient state: clear it once traffic flows again
+        # so the channel UI stops showing a stale failure.
+        if channel.last_error and channel.last_error.startswith("Meta could not deliver"):
+            channel.last_error = None
+            channel.updated_at = now_utc()
+            db.commit()
+        return
+    if state != "failed":
         return
     parts = []
     for error in status.get("errors") or []:

--- a/apps/api/app/services/audio.py
+++ b/apps/api/app/services/audio.py
@@ -15,27 +15,44 @@ import tempfile
 FFMPEG_TIMEOUT = 60
 
 
-async def to_whatsapp_voice(data: bytes, mime: str) -> tuple[bytes, str]:
-    """Transcode audio bytes to ogg/opus. Best-effort: returns the input
-    unchanged when it is already ogg or when ffmpeg is unavailable/fails."""
-    base_mime = (mime or "").split(";")[0].strip().lower()
-    if base_mime == "audio/ogg" or not shutil.which("ffmpeg"):
-        return data, mime
+async def _run_ffmpeg(args: list[str], stdin_data: bytes | None = None) -> bytes | None:
+    """Run ffmpeg returning stdout, or None when it fails or times out."""
     try:
         process = await asyncio.create_subprocess_exec(
-            "ffmpeg",
-            "-hide_banner", "-loglevel", "error",
-            "-i", "pipe:0",
-            "-vn", "-c:a", "libopus", "-b:a", "32k", "-ar", "48000", "-ac", "1",
-            "-f", "ogg", "pipe:1",
-            stdin=asyncio.subprocess.PIPE,
+            "ffmpeg", "-hide_banner", "-loglevel", "error", *args,
+            stdin=asyncio.subprocess.PIPE if stdin_data is not None else asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )
-        out, _ = await asyncio.wait_for(process.communicate(data), timeout=FFMPEG_TIMEOUT)
+        out, _ = await asyncio.wait_for(process.communicate(stdin_data), timeout=FFMPEG_TIMEOUT)
     except (OSError, asyncio.TimeoutError):
-        return data, mime
+        return None
     if process.returncode != 0 or not out:
+        return None
+    return out
+
+
+async def to_whatsapp_voice(data: bytes, mime: str) -> tuple[bytes, str]:
+    """Transcode audio bytes to ogg/opus. Best-effort: returns the input
+    unchanged when it is already ogg or when ffmpeg is unavailable/fails.
+
+    Two passes on purpose: MediaRecorder's fragmented mp4 carries a non-zero
+    start offset and micro-gaps between fragments. Transcoded directly to ogg
+    (with or without timestamp filters), Meta accepts the upload but drops the
+    message at delivery as application/octet-stream (error 131053), or ships a
+    voice note phones cannot download. Bouncing through WAV discards the source
+    timeline entirely, and the ogg encoded from it delivers and plays."""
+    base_mime = (mime or "").split(";")[0].strip().lower()
+    if base_mime == "audio/ogg" or not shutil.which("ffmpeg"):
+        return data, mime
+    wav = await _run_ffmpeg(["-i", "pipe:0", "-vn", "-f", "wav", "pipe:1"], data)
+    if wav is None:
+        return data, mime
+    out = await _run_ffmpeg(
+        ["-i", "pipe:0", "-c:a", "libopus", "-b:a", "32k", "-ar", "48000", "-ac", "1", "-f", "ogg", "pipe:1"],
+        wav,
+    )
+    if out is None:
         return data, mime
     return out, "audio/ogg"
 


### PR DESCRIPTION
## Problem
Voice notes recorded in the portal reached Meta (wamid returned) but were dropped at delivery with error 131053 — the ogg/opus upload was processed as application/octet-stream — or arrived as voice notes phones could not download.

## Root cause
MediaRecorder's fragmented mp4 carries a non-zero start offset and micro-gaps between fragments. A single-pass ffmpeg transcode preserves that broken timeline in the ogg; Meta's delivery-time validation rejects it. Timestamp filters (`asetpts`, `aresample=async`) produced files Meta accepted but phones could not download.

## Fix
- Transcode voice notes in two passes (source → WAV → ogg/opus), discarding the source timeline entirely. Verified A/B against the live Cloud API through a tunnel: the two-pass output delivers and plays every time.
- Clear the channel's stale delivery-error banner once sent/delivered/read statuses flow again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)