### PR TITLE
Humanize the AI agent on WhatsApp: read receipts, typing, gestures, formatting

### DIFF
--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -372,6 +372,13 @@ class Message(Base):
     sender_type: Mapped[str] = mapped_column(String(30), default="visitor")
     sender_name: Mapped[str | None] = mapped_column(String(180), nullable=True)
     external_message_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # The business's emoji reaction to this (visitor) message, mirrored in the
+    # portal so operators see the same gesture the customer saw on WhatsApp.
+    reaction: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    # Set when this reply quotes a specific earlier message (swipe-to-reply).
+    quoted_message_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("messages.id", ondelete="SET NULL"), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=now_utc)
 
     conversation: Mapped[Conversation] = relationship(back_populates="messages")

--- a/apps/api/app/routers/whatsapp_cloud_webhook.py
+++ b/apps/api/app/routers/whatsapp_cloud_webhook.py
@@ -21,6 +21,7 @@ from ..models import Message, WhatsAppCloudChannel, now_utc
 from ..ratelimit import whatsapp_cloud_webhook_rate_limit
 from ..security import decrypt_secret
 from ..services.whatsapp_cloud import fetch_media, send_text
+from ..services.whatsapp_format import markdown_to_whatsapp
 from ..services.whatsapp_inbound import InboundMessage, process_inbound
 
 
@@ -184,7 +185,13 @@ async def _handle_message(
     if not result.reply or not access_token or not channel.phone_number_id:
         return
     try:
-        wamid = await send_text(access_token, channel.phone_number_id, inbound.external_chat_id, result.reply)
+        wamid = await send_text(
+            access_token,
+            channel.phone_number_id,
+            inbound.external_chat_id,
+            markdown_to_whatsapp(result.reply),
+            context_message_id=result.quote_external_id,
+        )
     except HTTPException as exc:
         channel.last_error = f"The reply could not be sent: {exc.detail}"
         channel.updated_at = now_utc()

--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -328,6 +328,8 @@ class MessageOut(ORMModel):
     sender_type: str
     sender_name: str | None
     external_message_id: str | None = None
+    reaction: str | None = None
+    quoted_message_id: uuid.UUID | None = None
     created_at: datetime
     attachments: list[AttachmentOut] = []
 

--- a/apps/api/app/services/whatsapp.py
+++ b/apps/api/app/services/whatsapp.py
@@ -10,6 +10,7 @@ from ..models import Conversation, WhatsAppCloudChannel
 from ..security import decrypt_secret
 from .audio import audio_duration_seconds, to_whatsapp_voice
 from .whatsapp_cloud import send_media, send_text, upload_media
+from .whatsapp_format import markdown_to_whatsapp
 
 
 async def bridge_command(method: str, path: str, payload: dict | None = None, timeout: float = 20) -> dict:
@@ -38,16 +39,20 @@ async def bridge_command(method: str, path: str, payload: dict | None = None, ti
     return response.json()
 
 
-async def send_channel_message(db: Session, conversation: Conversation, content: str) -> str | None:
+async def send_channel_message(
+    db: Session, conversation: Conversation, content: str, *, quoted_external_id: str | None = None
+) -> str | None:
     """Deliver an operator message through the conversation's channel. Returns
-    the external message id, or None for channels without outbound delivery."""
+    the external message id, or None for channels without outbound delivery.
+
+    ``quoted_external_id`` sends it as a quoted reply (Cloud API only)."""
     if conversation.channel == "whatsapp":
         if not conversation.whatsapp_channel_id or not conversation.external_chat_id:
             raise HTTPException(status_code=409, detail="This conversation does not have a valid WhatsApp destination")
         result = await bridge_command(
             "POST",
             f"/channels/{conversation.whatsapp_channel_id}/send",
-            {"remote_jid": conversation.external_chat_id, "text": content},
+            {"remote_jid": conversation.external_chat_id, "text": markdown_to_whatsapp(content)},
         )
         return result.get("external_message_id")
     if conversation.channel == "whatsapp_cloud":
@@ -60,7 +65,8 @@ async def send_channel_message(db: Session, conversation: Conversation, content:
             decrypt_secret(channel.encrypted_access_token),
             channel.phone_number_id,
             conversation.external_chat_id,
-            content,
+            markdown_to_whatsapp(content),
+            context_message_id=quoted_external_id,
         )
     return None
 
@@ -78,6 +84,7 @@ async def send_channel_media(
     """Deliver an operator media message (image/audio/video/file) through the
     conversation's channel. Returns the external message id, or None for
     channels without outbound delivery (playground, widget)."""
+    caption = markdown_to_whatsapp(caption)
     seconds = None
     if kind == "audio" and conversation.channel in ("whatsapp", "whatsapp_cloud"):
         # WhatsApp only plays ogg/opus voice notes; browsers record webm/mp4.

--- a/apps/api/app/services/whatsapp_cloud.py
+++ b/apps/api/app/services/whatsapp_cloud.py
@@ -52,14 +52,21 @@ async def verify_phone_number(access_token: str, phone_number_id: str) -> dict:
         raise HTTPException(status_code=502, detail="Invalid response from the Meta API.") from exc
 
 
-async def send_text(access_token: str, phone_number_id: str, to: str, body: str) -> str | None:
-    """Send a text message; returns the outbound message id (wamid)."""
+async def send_text(
+    access_token: str, phone_number_id: str, to: str, body: str, context_message_id: str | None = None
+) -> str | None:
+    """Send a text message; returns the outbound message id (wamid).
+
+    ``context_message_id`` makes it a quoted reply (the swipe-to-reply look)
+    on the referenced message."""
     payload = {
         "messaging_product": "whatsapp",
         "to": to,
         "type": "text",
         "text": {"body": body[:MAX_TEXT_LENGTH]},
     }
+    if context_message_id:
+        payload["context"] = {"message_id": context_message_id}
     response = await _graph_request("POST", _graph_url(f"{phone_number_id}/messages"), access_token, json=payload)
     if response.status_code >= 400:
         raise HTTPException(status_code=502, detail=f"WhatsApp could not send the message: {_graph_error(response)}")
@@ -68,6 +75,38 @@ async def send_text(access_token: str, phone_number_id: str, to: str, body: str)
         return messages[0].get("id") if messages else None
     except ValueError:
         return None
+
+
+async def send_reaction(access_token: str, phone_number_id: str, to: str, message_id: str, emoji: str) -> None:
+    """React with an emoji to one of the customer's messages. Best-effort: a
+    reaction is a gesture, never worth failing the reply over."""
+    payload = {
+        "messaging_product": "whatsapp",
+        "to": to,
+        "type": "reaction",
+        "reaction": {"message_id": message_id, "emoji": emoji},
+    }
+    try:
+        await _graph_request("POST", _graph_url(f"{phone_number_id}/messages"), access_token, json=payload)
+    except HTTPException:
+        pass
+
+
+async def mark_read_with_typing(access_token: str, phone_number_id: str, message_id: str) -> None:
+    """Mark the conversation as read up to ``message_id`` (blue ticks) and show
+    the typing indicator while the reply is being generated. Meta dismisses the
+    indicator when a message is sent, or after ~25 seconds. Best-effort: the
+    reply must never depend on this call."""
+    payload = {
+        "messaging_product": "whatsapp",
+        "status": "read",
+        "message_id": message_id,
+        "typing_indicator": {"type": "text"},
+    }
+    try:
+        await _graph_request("POST", _graph_url(f"{phone_number_id}/messages"), access_token, json=payload)
+    except HTTPException:
+        pass
 
 
 async def upload_media(access_token: str, phone_number_id: str, data: bytes, mime: str, filename: str) -> str:

--- a/apps/api/app/services/whatsapp_format.py
+++ b/apps/api/app/services/whatsapp_format.py
@@ -1,0 +1,75 @@
+"""Outbound WhatsApp text shaping.
+
+LLMs write Markdown, but WhatsApp has its own inline syntax (*bold*, _italic_,
+~strikethrough~, ```monospace```) and renders everything else literally — a
+customer would see the raw asterisks of ``**bold**``. Stored messages keep
+their Markdown (the portal renders it); only the copy sent through a WhatsApp
+channel is converted here.
+
+This module also parses the optional "gesture" directives the agent may prefix
+its reply with ([react: 👍] / [quote: N]); the pipeline turns them into a Meta
+reaction or a quoted reply and strips them from the delivered text.
+"""
+
+import re
+
+_BOLD = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+_BOLD_ALT = re.compile(r"__(.+?)__", re.DOTALL)
+_STRIKE = re.compile(r"~~(.+?)~~", re.DOTALL)
+_HEADING = re.compile(r"^\s{0,3}#{1,6}\s+(.*)$")
+_LINK = re.compile(r"\[([^\]]+)\]\((https?://[^\s)]+)\)")
+_BULLET = re.compile(r"^(\s*)\*\s+")
+_TABLE_SEPARATOR = re.compile(r"^\s*\|?[\s:|-]+\|[\s:|-]*$")
+
+
+def markdown_to_whatsapp(text: str) -> str:
+    """Best-effort Markdown → WhatsApp formatting. Unknown constructs are left
+    as-is; the goal is that nothing renders as raw markup on a phone."""
+    if not text:
+        return text
+    lines = []
+    for line in text.splitlines():
+        if _TABLE_SEPARATOR.match(line) and "|" in line:
+            continue
+        heading = _HEADING.match(line)
+        if heading:
+            title = heading.group(1).strip().rstrip("#").strip()
+            line = f"*{title}*" if title else ""
+        elif "|" in line and line.strip().startswith("|"):
+            cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            line = " · ".join(cell for cell in cells if cell)
+        else:
+            line = _BULLET.sub(r"\1- ", line)
+        lines.append(line)
+    result = "\n".join(lines)
+    result = _BOLD.sub(r"*\1*", result)
+    result = _BOLD_ALT.sub(r"_\1_", result)
+    result = _STRIKE.sub(r"~\1~", result)
+    result = _LINK.sub(lambda m: m.group(2) if m.group(1).strip() == m.group(2) else f"{m.group(1)} ({m.group(2)})", result)
+    return result
+
+
+_DIRECTIVE = re.compile(r"^\s*\[(react|quote)\s*:\s*([^\]\n]{1,16})\][ \t]*\n?", re.IGNORECASE)
+_ALNUM = re.compile(r"[0-9A-Za-z]")
+
+
+def parse_reply_directives(text: str) -> tuple[str, str | None, int | None]:
+    """Split the agent's optional leading gesture directives from its reply.
+
+    Returns ``(clean_text, reaction_emoji, quote_index)``. Directives are only
+    honored at the very start of the reply; anything malformed is dropped so a
+    hallucinated directive can never leak to the customer."""
+    emoji: str | None = None
+    quote: int | None = None
+    remaining = text or ""
+    while True:
+        match = _DIRECTIVE.match(remaining)
+        if not match:
+            break
+        kind, value = match.group(1).lower(), match.group(2).strip()
+        if kind == "react" and emoji is None and value and len(value) <= 8 and not _ALNUM.search(value):
+            emoji = value
+        elif kind == "quote" and quote is None and value.isdigit():
+            quote = int(value)
+        remaining = remaining[match.end():]
+    return remaining.strip(), emoji, quote

--- a/apps/api/app/services/whatsapp_inbound.py
+++ b/apps/api/app/services/whatsapp_inbound.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session, selectinload
 from ..config import get_settings
 from ..database import SessionLocal
 from ..models import Agent, Conversation, Message, now_utc
+from ..security import decrypt_secret
 from .attachments import llm_text, store_attachment
 from .knowledge import build_system_prompt, retrieve_knowledge
 from .media import describe_image, transcribe_audio
@@ -25,6 +26,8 @@ from .providers import resolve_agent_credentials, resolve_provider_credentials
 from .tools import run_completion
 from .usage import record_usage
 from .whatsapp import send_channel_message
+from .whatsapp_cloud import mark_read_with_typing, send_reaction
+from .whatsapp_format import parse_reply_directives
 
 
 @dataclass
@@ -45,6 +48,8 @@ class InboundResult:
     conversation_id: uuid.UUID | None = None
     mode: str | None = None
     outbound_message_id: uuid.UUID | None = None
+    # External id of the visitor message the reply quotes (swipe-to-reply).
+    quote_external_id: str | None = None
 
 
 def _media_placeholder(kind: str) -> str:
@@ -175,7 +180,87 @@ async def process_inbound(
         schedule_debounced_reply(conversation.id)
         return InboundResult(accepted=True, conversation_id=conversation.id, mode="ai")
 
+    await _signal_read_and_typing(channel, conversation, inbound.external_message_id)
     return await _reply_with_ai(db, channel, conversation, llm_content)
+
+
+# Injected into the system prompt for Cloud API conversations (kept in the
+# customer's language, like the rest of the LLM-facing scaffolding). The model
+# decides IF and WHEN with conversational judgment; the code only executes.
+WHATSAPP_GESTURE_RULES = (
+    "GESTOS DE WHATSAPP (opcionales; úsalos con moderación y criterio, como lo haría una persona):\n"
+    "- Cuando el último mensaje del cliente no necesite una respuesta en texto y un gesto baste — en cualquier "
+    "idioma: un agradecimiento, una despedida, una confirmación breve, un elogio, algo gracioso, un emoji —, "
+    "puedes responder solo con una reacción: escribe únicamente la línea [react: EMOJI], eligiendo el emoji que "
+    "mejor exprese tu reacción a ese mensaje y su tono (👍 ❤️ 😂 🙌 🎉 o cualquier otro). También puedes poner esa "
+    "línea primero y añadir texto debajo.\n"
+    "- La mayoría de las respuestas no necesitan ningún gesto. Nunca reacciones dos veces seguidas."
+)
+
+WHATSAPP_QUOTE_RULE = (
+    "- El cliente envió varios mensajes seguidos, numerados abajo. Si tu respuesta se centra en uno en "
+    "particular, puedes comenzar con la línea [quote: N] para responder citándolo (como al deslizar un "
+    "mensaje en WhatsApp). Cítalo solo cuando aclare a qué respondes:\n{listing}"
+)
+
+
+def _trailing_visitor_burst(history: list[Message]) -> list[Message]:
+    """The consecutive visitor messages at the end of the history — the burst
+    the agent is about to answer, oldest first."""
+    burst: list[Message] = []
+    for item in reversed(history):
+        if item.role != "user":
+            break
+        burst.append(item)
+    return list(reversed(burst))
+
+
+def _gesture_rules(burst: list[Message]) -> str:
+    rules = WHATSAPP_GESTURE_RULES
+    if len(burst) > 1:
+        listing = "\n".join(f"[{index}] {llm_text(item)[:160]}" for index, item in enumerate(burst, start=1))
+        rules += "\n" + WHATSAPP_QUOTE_RULE.format(listing=listing)
+    return rules
+
+
+async def _apply_gestures(
+    db: Session, channel, conversation: Conversation, completion_text: str, burst: list[Message]
+) -> tuple[str, uuid.UUID | None, str | None]:
+    """Execute the reply's leading gesture directives (react/quote) and strip
+    them. Returns ``(clean_text, quoted_message_id, quote_external_id)``."""
+    clean_text, emoji, quote_index = parse_reply_directives(completion_text)
+    quoted_id: uuid.UUID | None = None
+    quote_external: str | None = None
+    if not channel.encrypted_access_token or not channel.phone_number_id:
+        return clean_text, None, None
+    if emoji and burst and burst[-1].external_message_id:
+        target = burst[-1]
+        await send_reaction(
+            decrypt_secret(channel.encrypted_access_token),
+            channel.phone_number_id,
+            conversation.external_chat_id,
+            target.external_message_id,
+            emoji,
+        )
+        target.reaction = emoji
+    if quote_index and 1 <= quote_index <= len(burst) and burst[quote_index - 1].external_message_id:
+        quoted = burst[quote_index - 1]
+        quoted_id = quoted.id
+        quote_external = quoted.external_message_id
+    return clean_text, quoted_id, quote_external
+
+
+async def _signal_read_and_typing(channel, conversation: Conversation, message_external_id: str | None) -> None:
+    """Blue-tick the visitor's burst and show "typing..." while the AI reply is
+    generated — the moment the quiet window closes is when a human would have
+    read the messages. Cloud API only; the bridge has no such signal yet."""
+    if conversation.channel != "whatsapp_cloud" or not message_external_id:
+        return
+    if not channel.encrypted_access_token or not channel.phone_number_id:
+        return
+    await mark_read_with_typing(
+        decrypt_secret(channel.encrypted_access_token), channel.phone_number_id, message_external_id
+    )
 
 
 async def _reply_with_ai(db: Session, channel, conversation: Conversation, retrieval_query: str) -> InboundResult:
@@ -201,8 +286,12 @@ async def _reply_with_ai(db: Session, channel, conversation: Conversation, retri
         .limit(agent.memory_limit)
     ).all()
     history = list(reversed(history))
+    burst = _trailing_visitor_burst(history)
+    system_content = build_system_prompt(agent, knowledge.text)
+    if conversation.channel == "whatsapp_cloud":
+        system_content += "\n\n" + _gesture_rules(burst)
     messages = [
-        {"role": "system", "content": build_system_prompt(agent, knowledge.text)},
+        {"role": "system", "content": system_content},
         *[{"role": item.role, "content": llm_text(item)} for item in history],
     ]
     base_url, api_key = credentials
@@ -222,26 +311,38 @@ async def _reply_with_ai(db: Session, channel, conversation: Conversation, retri
         db.commit()
         return InboundResult(accepted=True, conversation_id=conversation.id, mode="ai")
 
-    outbound = Message(
-        conversation_id=conversation.id,
-        role="assistant",
-        content=completion.text,
-        sources=knowledge.sources,
-        tool_calls=completion.tool_calls,
-        sender_type="ai",
-        sender_name=agent.name,
-    )
+    reply_text = completion.text
+    quoted_message_id: uuid.UUID | None = None
+    quote_external_id: str | None = None
+    if conversation.channel == "whatsapp_cloud":
+        reply_text, quoted_message_id, quote_external_id = await _apply_gestures(
+            db, channel, conversation, completion.text, burst
+        )
+
+    outbound = None
+    if reply_text:
+        outbound = Message(
+            conversation_id=conversation.id,
+            role="assistant",
+            content=reply_text,
+            sources=knowledge.sources,
+            tool_calls=completion.tool_calls,
+            sender_type="ai",
+            sender_name=agent.name,
+            quoted_message_id=quoted_message_id,
+        )
+        db.add(outbound)
     record_usage(db, agent.agency_id, agent.id, agent.provider, agent.model.strip(), completion)
     conversation.updated_at = now_utc()
     channel.last_error = None
-    db.add(outbound)
     db.commit()
     return InboundResult(
         accepted=True,
-        reply=completion.text,
+        reply=reply_text or None,
         conversation_id=conversation.id,
         mode="ai",
-        outbound_message_id=outbound.id,
+        outbound_message_id=outbound.id if outbound else None,
+        quote_external_id=quote_external_id,
     )
 
 
@@ -299,6 +400,7 @@ async def _debounced_reply(conversation_id: uuid.UUID) -> None:
             if item.role != "user":
                 break
             burst.append(llm_text(item))
+        await _signal_read_and_typing(channel, conversation, last.external_message_id)
         try:
             result = await _reply_with_ai(db, channel, conversation, "\n".join(reversed(burst)))
         except Exception as exc:
@@ -309,7 +411,9 @@ async def _debounced_reply(conversation_id: uuid.UUID) -> None:
         if not result.reply:
             return
         try:
-            external_id = await send_channel_message(db, conversation, result.reply)
+            external_id = await send_channel_message(
+                db, conversation, result.reply, quoted_external_id=result.quote_external_id
+            )
         except HTTPException as exc:
             channel.last_error = f"The reply could not be sent: {exc.detail}"
             channel.updated_at = now_utc()

--- a/apps/api/migrations/versions/0022_message_gestures.py
+++ b/apps/api/migrations/versions/0022_message_gestures.py
@@ -1,0 +1,35 @@
+"""Message gestures: the business's emoji reaction to a visitor message and
+the quoted-reply reference (swipe-to-reply), so the portal can mirror what the
+customer sees on WhatsApp.
+
+Revision ID: 0022_message_gestures
+Revises: 0021_drop_legacy_portal_login
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0022_message_gestures"
+down_revision = "0021_drop_legacy_portal_login"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("messages", sa.Column("reaction", sa.String(length=16), nullable=True))
+    op.add_column("messages", sa.Column("quoted_message_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        "fk_messages_quoted_message_id",
+        "messages",
+        "messages",
+        ["quoted_message_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_messages_quoted_message_id", "messages", type_="foreignkey")
+    op.drop_column("messages", "quoted_message_id")
+    op.drop_column("messages", "reaction")

--- a/apps/api/tests/test_whatsapp_cloud.py
+++ b/apps/api/tests/test_whatsapp_cloud.py
@@ -183,6 +183,8 @@ def test_webhook_text_message_creates_conversation_and_replies(authenticated_cli
     monkeypatch.setattr(whatsapp_inbound_service, "run_completion", fake_completion)
     fake_send = AsyncMock(return_value="wamid.out-1")
     monkeypatch.setattr(webhook_router, "send_text", fake_send)
+    fake_read = AsyncMock()
+    monkeypatch.setattr(whatsapp_inbound_service, "mark_read_with_typing", fake_read)
 
     payload = _webhook_payload(
         [{"from": "5730011", "id": "wamid.in-1", "type": "text", "text": {"body": "Are you open?"}}],
@@ -190,7 +192,11 @@ def test_webhook_text_message_creates_conversation_and_replies(authenticated_cli
     )
     response = _post_signed(client, channel["id"], payload)
     assert response.status_code == 200, response.text
-    fake_send.assert_awaited_once_with("meta-access-token", "111", "5730011", "We are open every day.")
+    fake_send.assert_awaited_once_with(
+        "meta-access-token", "111", "5730011", "We are open every day.", context_message_id=None
+    )
+    # The visitor's message is blue-ticked with the typing indicator before the reply.
+    fake_read.assert_awaited_once_with("meta-access-token", "111", "wamid.in-1")
 
     conversation = client.get("/api/conversations").json()[0]
     detail = client.get(f"/api/conversations/{conversation['id']}").json()
@@ -228,6 +234,51 @@ def test_webhook_ignores_statuses_and_unsupported_types(authenticated_client: Te
     sticker = _webhook_payload([{"from": "5730011", "id": "wamid.stk", "type": "sticker", "sticker": {"id": "1"}}])
     assert _post_signed(client, channel["id"], sticker).status_code == 200
     assert fake_completion.await_count == 0
+
+
+def test_reply_react_gesture_sends_reaction_without_text(authenticated_client: TestClient, monkeypatch):
+    client = authenticated_client
+    _customer, _agent, channel = _setup_channel(client)
+    fake_completion = AsyncMock(return_value=ai_service.Completion(text="[react: 👍]"))
+    monkeypatch.setattr(whatsapp_inbound_service, "run_completion", fake_completion)
+    fake_send = AsyncMock(return_value="wamid.out-1")
+    monkeypatch.setattr(webhook_router, "send_text", fake_send)
+    fake_react = AsyncMock()
+    monkeypatch.setattr(whatsapp_inbound_service, "send_reaction", fake_react)
+    monkeypatch.setattr(whatsapp_inbound_service, "mark_read_with_typing", AsyncMock())
+
+    payload = _webhook_payload([{"from": "5730011", "id": "wamid.in-1", "type": "text", "text": {"body": "gracias!"}}])
+    assert _post_signed(client, channel["id"], payload).status_code == 200
+    fake_react.assert_awaited_once_with("meta-access-token", "111", "5730011", "wamid.in-1", "👍")
+    fake_send.assert_not_awaited()
+
+    conversation = client.get("/api/conversations").json()[0]
+    detail = client.get(f"/api/conversations/{conversation['id']}").json()
+    # Reaction stored on the visitor message; no empty assistant bubble.
+    assert [item["sender_type"] for item in detail["messages"]] == ["visitor"]
+    assert detail["messages"][0]["reaction"] == "👍"
+
+
+def test_reply_quote_gesture_quotes_the_visitor_message(authenticated_client: TestClient, monkeypatch):
+    client = authenticated_client
+    _customer, _agent, channel = _setup_channel(client)
+    fake_completion = AsyncMock(return_value=ai_service.Completion(text="[quote: 1] Claro, hasta las 10pm."))
+    monkeypatch.setattr(whatsapp_inbound_service, "run_completion", fake_completion)
+    fake_send = AsyncMock(return_value="wamid.out-1")
+    monkeypatch.setattr(webhook_router, "send_text", fake_send)
+    monkeypatch.setattr(whatsapp_inbound_service, "mark_read_with_typing", AsyncMock())
+
+    payload = _webhook_payload([{"from": "5730011", "id": "wamid.in-1", "type": "text", "text": {"body": "¿hasta qué hora abren?"}}])
+    assert _post_signed(client, channel["id"], payload).status_code == 200
+    fake_send.assert_awaited_once_with(
+        "meta-access-token", "111", "5730011", "Claro, hasta las 10pm.", context_message_id="wamid.in-1"
+    )
+
+    conversation = client.get("/api/conversations").json()[0]
+    detail = client.get(f"/api/conversations/{conversation['id']}").json()
+    visitor, assistant = detail["messages"]
+    assert assistant["content"] == "Claro, hasta las 10pm."
+    assert assistant["quoted_message_id"] == visitor["id"]
 
 
 def test_webhook_failed_status_surfaces_delivery_error(authenticated_client: TestClient):
@@ -332,7 +383,9 @@ def test_webhook_human_mode_skips_ai(authenticated_client: TestClient, monkeypat
     reply = client.post(f"/api/conversations/{conversation['id']}/reply", json={"content": "Hola Maria, te ayudo yo."})
     assert reply.status_code == 200, reply.text
     assert reply.json()["messages"][-1]["external_message_id"] == "wamid.human-1"
-    operator_send.assert_awaited_once_with("meta-access-token", "111", "5730011", "Hola Maria, te ayudo yo.")
+    operator_send.assert_awaited_once_with(
+        "meta-access-token", "111", "5730011", "Hola Maria, te ayudo yo.", context_message_id=None
+    )
 
 
 def test_webhook_image_uses_capability(authenticated_client: TestClient, monkeypatch):

--- a/apps/api/tests/test_whatsapp_format.py
+++ b/apps/api/tests/test_whatsapp_format.py
@@ -1,0 +1,44 @@
+from app.services.whatsapp_format import markdown_to_whatsapp, parse_reply_directives
+
+
+def test_markdown_bold_and_italic_become_whatsapp_syntax():
+    assert markdown_to_whatsapp("**hola** y __esto__ y ~~eso~~") == "*hola* y _esto_ y ~eso~"
+
+
+def test_headings_become_bold_lines():
+    assert markdown_to_whatsapp("## Postres\n- Tiramisú") == "*Postres*\n- Tiramisú"
+
+
+def test_star_bullets_become_dashes():
+    assert markdown_to_whatsapp("* uno\n* dos") == "- uno\n- dos"
+
+
+def test_links_keep_text_and_url():
+    assert markdown_to_whatsapp("Mira [el menú](https://x.co/m)") == "Mira el menú (https://x.co/m)"
+
+
+def test_tables_degrade_to_plain_lines():
+    text = "| Pizza | Precio |\n|---|---|\n| Caprese | $22 |"
+    assert markdown_to_whatsapp(text) == "Pizza · Precio\nCaprese · $22"
+
+
+def test_plain_text_untouched():
+    assert markdown_to_whatsapp("hola, ¿cómo estás?") == "hola, ¿cómo estás?"
+
+
+def test_parse_react_directive():
+    assert parse_reply_directives("[react: 👍]") == ("", "👍", None)
+
+
+def test_parse_react_with_text_and_quote():
+    clean, emoji, quote = parse_reply_directives("[react: ❤️]\n[quote: 2]\nClaro que sí")
+    assert (clean, emoji, quote) == ("Claro que sí", "❤️", 2)
+
+
+def test_malformed_directives_are_dropped():
+    assert parse_reply_directives("[react: thumbsup] hola") == ("hola", None, None)
+    assert parse_reply_directives("[quote: dos] hola") == ("hola", None, None)
+
+
+def test_text_without_directives_untouched():
+    assert parse_reply_directives("Con gusto [react: 👍] no aplica") == ("Con gusto [react: 👍] no aplica", None, None)

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -581,6 +581,16 @@ textarea { line-height: 1.55; }
 .portal-messages small { color: #7a8291; font-size: 12px; }
 .portal-messages p { margin: 4px 0 0; padding: 11px 13px; border-radius: 4px 11px 11px; background: #f0f2f5; }
 .portal-messages article.user p { color: white; border-radius: 11px 4px 11px 11px; background: var(--portal-color); }
+/* WhatsApp-style gestures mirrored in the chat views: the business's emoji
+   reaction on a visitor bubble and the quoted-reply snippet inside a bubble. */
+.reaction-badge { display: inline-flex; width: fit-content; margin-top: -12px; margin-left: 14px; padding: 3px 9px; font-size: 15px; line-height: 1.3; background: var(--surface, #fff); border: 1px solid rgba(10, 14, 29, .12); border-radius: 999px; box-shadow: 0 1px 3px rgba(10, 14, 29, .16); position: relative; z-index: 1; }
+.inbox-message.user .reaction-badge, .portal-messages article.user .reaction-badge { margin-left: 0; margin-right: 14px; }
+.inbox-message, .portal-messages article { display: flex; flex-direction: column; align-items: flex-start; }
+.inbox-message.user, .portal-messages article.user { align-items: flex-end; }
+.quoted-snippet { display: block; margin-bottom: 7px; padding: 5px 9px; font-size: 12.5px; line-height: 1.35; border-left: 3px solid currentColor; border-radius: 5px; background: rgba(10, 14, 29, .07); opacity: .85; }
+.quoted-snippet strong { display: block; font-size: 11.5px; opacity: .8; }
+.portal-messages article.user .quoted-snippet, .inbox-message.user .quoted-snippet { background: rgba(255, 255, 255, .18); }
+
 .portal-composer { padding: 13px; display: flex; gap: 8px; border-top: 1px solid var(--line); }
 .portal-composer input { flex: 1; }
 .portal-composer button { width: 42px; display: grid; place-items: center; color: white; border: 0; border-radius: 7px; background: var(--portal-color); }

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -6,6 +6,7 @@ import { PageHead } from "@/components/ui";
 import { AttachButton, MessageAttachments, PendingAttachment, RecordButton, useFileDrop, type GalleryImage } from "@/components/attachments";
 import { MediaPanel } from "@/components/media-panel";
 import { RichText } from "@/components/rich-text";
+import { QuotedSnippet, ReactionBadge } from "@/components/message-gestures";
 import { ListRowsSkeleton } from "@/components/skeleton";
 import { useToast } from "@/components/toast";
 import { api, ApiError, apiUrl, messageFrom } from "@/lib/api";
@@ -276,8 +277,9 @@ export default function InboxPage() {
                   <div key={message.id} className={`inbox-message ${message.role}${grouped ? " grouped" : ""}`}>
                     {!grouped && <small>{message.sender_name || (message.role === "assistant" ? t("inbox.senderAgent") : t("inbox.senderVisitor"))}</small>}
                     <MessageAttachments attachments={message.attachments} urlFor={attachmentUrl} gallery={gallery} stamp={stamp} />
-                    {message.content ? <p><RichText text={message.content} /><time className="msg-time">{stamp}</time></p>
+                    {message.content ? <p><QuotedSnippet messages={selected.messages ?? []} quotedId={message.quoted_message_id} /><RichText text={message.content} /><time className="msg-time">{stamp}</time></p>
                       : !hasAudio && message.attachments?.length ? <time className="msg-time bare">{stamp}</time> : null}
+                    <ReactionBadge emoji={message.reaction} />
                   </div>
                 );
               })}

--- a/apps/web/app/portal/[slug]/page.tsx
+++ b/apps/web/app/portal/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { AttachButton, MessageAttachments, PendingAttachment, RecordButton, useF
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { MediaPanel } from "@/components/media-panel";
 import { RichText } from "@/components/rich-text";
+import { QuotedSnippet, ReactionBadge } from "@/components/message-gestures";
 import { Alert, EmptyState } from "@/components/ui";
 import { api, ApiError, apiUrl, messageFrom } from "@/lib/api";
 import { formatTime, formatWhen, isNearBottom, isSameOpenThread } from "@/lib/datetime";
@@ -146,8 +147,9 @@ function PortalInbox({ slug, portal, logout }: { slug: string; portal: PortalPub
               return <article key={message.id} className={`${message.role}${grouped ? " grouped" : ""}`}>
                 {!grouped && <small>{message.sender_name || (message.role === "assistant" ? t("portal.inbox.conversation.agent") : t("portal.inbox.conversation.visitor"))}</small>}
                 <MessageAttachments attachments={message.attachments} urlFor={attachmentUrl} gallery={gallery} stamp={stamp} />
-                {message.content ? <p><RichText text={message.content} /><time className="msg-time">{stamp}</time></p>
+                {message.content ? <p><QuotedSnippet messages={selected.messages ?? []} quotedId={message.quoted_message_id} /><RichText text={message.content} /><time className="msg-time">{stamp}</time></p>
                   : !hasAudio && message.attachments?.length ? <time className="msg-time bare">{stamp}</time> : null}
+                <ReactionBadge emoji={message.reaction} />
               </article>;
             })}</div>{error && <Alert>{error}</Alert>}{pendingFile && <PendingAttachment file={pendingFile} onCancel={() => setPendingFile(null)} />}<form onSubmit={reply} className="portal-composer"><AttachButton onFile={setPendingFile} disabled={selected.mode !== "human" || busy} title={t("chat.attachFile")} /><RecordButton onRecorded={sendAttachment} onError={() => setError(t("chat.micDenied"))} disabled={selected.mode !== "human" || busy} title={t("chat.recordAudio")} titleStop={t("chat.stopRecording")} /><input ref={replyInputRef} name="content" required={!pendingFile} disabled={selected.mode !== "human" || busy} placeholder={selected.mode === "human" ? t("portal.inbox.conversation.replyPlaceholder") : t("portal.inbox.conversation.takeControlToReply")} /><button disabled={selected.mode !== "human" || busy}>{busy ? <LoaderCircle className="spin" size={18} /> : <Send size={18} />}</button></form><MediaPanel open={mediaOpen} onClose={() => setMediaOpen(false)} messages={selected.messages ?? []} urlFor={attachmentUrl} /></>}</section></div> : <EmptyState icon={<Inbox />} title={t("portal.inbox.empty.title")} description={t("portal.inbox.empty.description")} />}</section></main>;
 }

--- a/apps/web/components/message-gestures.tsx
+++ b/apps/web/components/message-gestures.tsx
@@ -1,0 +1,22 @@
+import type { Message } from "@/types";
+
+/** Quoted-reply snippet shown inside a bubble, mirroring WhatsApp's
+ * swipe-to-reply look so operators see the same thread the customer saw. */
+export function QuotedSnippet({ messages, quotedId }: { messages: Message[]; quotedId?: string | null }) {
+  if (!quotedId) return null;
+  const quoted = messages.find((message) => message.id === quotedId);
+  if (!quoted) return null;
+  const excerpt = (quoted.content || "").slice(0, 140);
+  return (
+    <span className="quoted-snippet">
+      {quoted.sender_name && <strong>{quoted.sender_name}</strong>}
+      <span>{excerpt || "…"}</span>
+    </span>
+  );
+}
+
+/** The business's emoji reaction to a visitor message. */
+export function ReactionBadge({ emoji }: { emoji?: string | null }) {
+  if (!emoji) return null;
+  return <span className="reaction-badge">{emoji}</span>;
+}

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -126,7 +126,7 @@ export type ToolCallMeta = { name: string; arguments: Record<string, unknown>; r
 
 export type Source = { id: string; filename: string; excerpt: string };
 export type Attachment = { id: string; kind: "image" | "audio" | "video" | "file"; mime: string; filename: string | null; size_bytes: number };
-export type Message = { id: string; role: "user" | "assistant"; content: string; sources: Source[]; tool_calls?: ToolCallMeta[] | null; sender_type: "visitor" | "ai" | "human"; sender_name: string | null; created_at: string; attachments?: Attachment[] };
+export type Message = { id: string; role: "user" | "assistant"; content: string; sources: Source[]; tool_calls?: ToolCallMeta[] | null; sender_type: "visitor" | "ai" | "human"; sender_name: string | null; reaction?: string | null; quoted_message_id?: string | null; created_at: string; attachments?: Attachment[] };
 
 export type ConversationInbox = {
   id: string;


### PR DESCRIPTION
## What
Four polish features that make the AI agent feel human on the WhatsApp Cloud API channel:

1. **Read receipts + typing**: when the reply-debounce window closes and generation starts, one Meta call blue-ticks the visitor's burst and shows the typing indicator (auto-dismissed when the reply lands). AI mode only.
2. **Markdown → WhatsApp formatting**: outbound text (AI replies, operator replies, captions) is converted to WhatsApp's syntax at send time — customers no longer see raw `**asterisks**`. Stored messages keep their Markdown for the portal.
3. **Reactions**: the model may answer a message that needs no text (thanks, goodbye, a joke — any language) with an emoji reaction of its choice, via a `[react: EMOJI]` directive parsed and executed by code.
4. **Quoted replies**: in a multi-message burst the model may quote the specific message it answers via `[quote: N]` (swipe-to-reply look).

Gestures are persisted (`messages.reaction`, `messages.quoted_message_id`, migration `0022`) and mirrored in the portal and agency inbox with WhatsApp-style UI.

## Notes
- The gesture instructions live in the platform-injected system prompt — agencies configure nothing; their own agent instructions can modulate or disable the behavior in natural language.
- Everything is best-effort and additive: malformed directives are stripped, failed gesture calls never block the reply, and with no directives behavior is exactly as before.
- Tested end-to-end against the live Cloud API through a local tunnel. 72 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)