### PR TITLE
Move the documentation into the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://openlivery.com/docs"><strong>Documentation</strong></a> ·
-  <a href="https://openlivery.com/docs/getting-started">Quick start</a> ·
-  <a href="https://openlivery.com/docs/self-hosting">Self-hosting</a> ·
+  <a href="docs/"><strong>Documentation</strong></a> ·
+  <a href="docs/en/getting-started.md">Quick start</a> ·
+  <a href="docs/en/self-hosting.md">Self-hosting</a> ·
   <a href="https://github.com/sarrazola/openlivery/discussions">Discussions</a>
 </p>
 
@@ -31,45 +31,45 @@ keys and self-host the whole thing with one command.
 
 ## Documentation
 
-Full documentation lives at **[openlivery.com/docs](https://openlivery.com/docs)**.
+Full documentation lives in **[docs/](docs/)**, in English and Spanish.
 
 | Guide | What it covers |
 | --- | --- |
-| [Getting started](https://openlivery.com/docs/getting-started) | Run the stack with Docker and create your first agency |
-| [Configuration](https://openlivery.com/docs/configuration) | Environment variables, secrets, ports and the gateway |
-| [Architecture](https://openlivery.com/docs/architecture) | The services, the data model and tenant isolation |
-| [Self-hosting](https://openlivery.com/docs/self-hosting) | Deploy to a server, back up, upgrade and troubleshoot |
-| [Contributing](https://openlivery.com/docs/contributing) | Run the project locally, tests and conventions |
-| [Push notifications](docs/push-notifications.md) | Optional, provider-agnostic notifications for the mobile app |
-| [WhatsApp Cloud API](docs/connections/whatsapp-cloud-api.md) | Connect a number with the official Meta API, end to end ([en español](docs/connections/whatsapp-cloud-api.es.md)) |
+| [Getting started](docs/en/getting-started.md) | Run the stack with Docker and create your first agency |
+| [Configuration](docs/en/configuration.md) | Environment variables, secrets, ports and the gateway |
+| [Architecture](docs/en/architecture.md) | The services, the data model and tenant isolation |
+| [Self-hosting](docs/en/self-hosting.md) | Deploy to a server, back up, upgrade and troubleshoot |
+| [Contributing](docs/en/contributing.md) | Run the project locally, tests and conventions |
+| [Push notifications](docs/en/push-notifications.md) | Optional, provider-agnostic notifications for the mobile app |
+| [WhatsApp Cloud API](docs/en/whatsapp-cloud-api.md) | Connect a number with the official Meta API, end to end ([en español](docs/es/whatsapp-cloud-api.md)) |
 
 ## Features
 
-**Agents** — [docs](https://openlivery.com/docs/agents)
+**Agents** — [docs](docs/en/agents.md)
 - ✅ Instructions, personality, per-client & per-agent context, timezone, and temperature / max-tokens / memory controls
 - ✅ Multimodal capabilities: **image recognition** (vision) and **audio transcription** for incoming media
 - ✅ Creation wizard with a live token counter and industry starter templates
 
-**Knowledge base** — [docs](https://openlivery.com/docs/knowledge-base)
+**Knowledge base** — [docs](docs/en/knowledge-base.md)
 - ✅ Manual context, structured **Q&A pairs** and PDF upload, with embedding-based semantic retrieval (keyword fallback)
 - ✅ Portable JSON embeddings — no database extension required
 
-**AI providers** — [docs](https://openlivery.com/docs/ai-providers)
+**AI providers** — [docs](docs/en/ai-providers.md)
 - ✅ Bring-your-own **OpenAI** (Responses API) and **Anthropic** (Messages API) keys — agency-level, encrypted, and validated when saved
 - ✅ Any OpenAI-compatible endpoint via per-connection base URL + model
 
-**Custom tools** — [docs](https://openlivery.com/docs/custom-tools)
+**Custom tools** — [docs](docs/en/custom-tools.md)
 - ✅ Per-agent **HTTP tools**: any REST endpoint with path/query/body parameters, encrypted auth headers and an SSRF guard
 - ✅ **MCP servers** (Streamable HTTP or SSE) with test-before-save connection checks and cached tool discovery
 - ✅ Tool usage recorded per reply and surfaced in the playground, including failure details
 
-**Channels** — [WhatsApp](https://openlivery.com/docs/whatsapp) · [Web widget](https://openlivery.com/docs/web-widget)
+**Channels** — [WhatsApp](docs/en/whatsapp.md) · [Web widget](docs/en/web-widget.md)
 - ✅ **WhatsApp Cloud API** (official Meta API) — bring your own Meta app credentials, signed webhooks, per-client number
 - ✅ **WhatsApp QR** through Baileys — QR link, per-client number, encrypted persistent session
 - ✅ Embeddable **web chat widget** for any website
 - 🚧 Instagram DM, Facebook Messenger *(planned)*
 
-**Operations** — [Inbox](https://openlivery.com/docs/inbox) · [Client portal](https://openlivery.com/docs/client-portal) · [Dashboard](https://openlivery.com/docs/dashboard)
+**Operations** — [Inbox](docs/en/inbox.md) · [Client portal](docs/en/client-portal.md) · [Dashboard](docs/en/dashboard.md)
 - ✅ Unified **Inbox** with server-side search, filter tabs, unread tracking, pagination and human takeover
 - ✅ Per-client **portal** with its own login and Inbox, optionally served under the client's **own custom domain** (DNS-verified, automatic HTTPS)
 - ✅ **Dashboard** with activity, top agents, token usage by model and a date-range filter
@@ -90,7 +90,7 @@ at rest. Every query is scoped by `agency_id` for tenant isolation, and public
 endpoints (sign-in and the web widget) are rate-limited per client IP. A Caddy
 gateway serves the app and API from a single origin (`/api/*` → backend).
 
-Read more in the [architecture guide](https://openlivery.com/docs/architecture).
+Read more in the [architecture guide](docs/en/architecture.md).
 
 ## Quick start
 
@@ -108,9 +108,9 @@ Ports clashing? `API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up`.
 Prefer not to build? `make pull` runs the prebuilt images published to GHCR.
 
 The full walkthrough — first agency, provider keys, agents, knowledge and
-channels — is in the **[getting started guide](https://openlivery.com/docs/getting-started)**.
+channels — is in the **[getting started guide](docs/en/getting-started.md)**.
 Deploying to a public server (reverse proxy, TLS, backups) is covered in
-**[self-hosting](https://openlivery.com/docs/self-hosting)**.
+**[self-hosting](docs/en/self-hosting.md)**.
 
 ## Community & support
 
@@ -148,7 +148,7 @@ checklist, including why you publish it rather than us, is in
 ## Contributing
 
 Run the project locally, the test suites and the conventions are documented in
-the **[contributing guide](https://openlivery.com/docs/contributing)**. In short:
+the **[contributing guide](docs/en/contributing.md)**. In short:
 all code, identifiers, comments and docs are in English; end-user UI is localized
 (English default, Spanish) through the typed i18n system in `apps/web/lib/i18n`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,83 @@
+# OpenLivery documentation
+
+Every guide lives here, in the repository, so a change to the product and the
+change to its documentation travel in the same pull request. Guides are written
+in English and Spanish; code, identifiers and commands stay English in both.
+
+Adding a guide: write `en/<slug>.md` and `es/<slug>.md`, then list it below.
+
+## English
+
+Everything you need to build, brand and operate AI agents for your clients.
+
+**Getting started**
+
+- [Getting started](en/getting-started.md) — Run the full stack with Docker and create your first agency in minutes.
+- [Configuration](en/configuration.md) — Environment variables, secrets, ports and gateway settings.
+
+**Concepts**
+
+- [Architecture](en/architecture.md) — The three services, the data model and how tenant isolation works.
+
+**Agents**
+
+- [Agents](en/agents.md) — Instructions, context, models and multimodal capabilities.
+- [Knowledge base](en/knowledge-base.md) — Manual context, Q&A pairs, PDFs and semantic retrieval.
+- [AI providers](en/ai-providers.md) — Connect OpenAI and Anthropic keys and pick per-agent models.
+- [Custom tools](en/custom-tools.md) — Let agents call HTTP endpoints and MCP servers during a conversation.
+
+**Channels**
+
+- [WhatsApp](en/whatsapp.md) — Link a number per client through the Baileys bridge and hand off to a human.
+- [WhatsApp Cloud API](en/whatsapp-cloud-api.md) — Connect a number through Meta's official Cloud API: app, token, webhook and going live.
+- [Web chat widget](en/web-widget.md) — Embed an agent on any website with a single snippet.
+
+**Operating**
+
+- [Inbox](en/inbox.md) — Search, filter and take over conversations from AI to human.
+- [Client portal & domains](en/client-portal.md) — Give each client a branded portal on its own custom domain.
+- [Dashboard](en/dashboard.md) — Activity, top agents and token usage by model.
+- [Push notifications](en/push-notifications.md) — The provider seam for mobile push: what ships, what it costs and how to register one.
+
+**Self-hosting**
+
+- [Self-hosting](en/self-hosting.md) — Deploy to a server, back up data, upgrade and troubleshoot.
+- [Contributing](en/contributing.md) — Run the project locally, the test suites and the conventions.
+
+## Español
+
+Todo lo que necesitas para construir, marcar y operar agentes de IA para tus clientes.
+
+**Primeros pasos**
+
+- [Primeros pasos](es/getting-started.md) — Levanta el stack completo con Docker y crea tu primera agencia en minutos.
+- [Configuración](es/configuration.md) — Variables de entorno, secretos, puertos y ajustes del gateway.
+
+**Conceptos**
+
+- [Arquitectura](es/architecture.md) — Los tres servicios, el modelo de datos y cómo funciona el aislamiento por tenant.
+
+**Agentes**
+
+- [Agentes](es/agents.md) — Instrucciones, contexto, modelos y capacidades multimodales.
+- [Base de conocimiento](es/knowledge-base.md) — Contexto manual, pares de preguntas y respuestas, PDFs y recuperación semántica.
+- [Proveedores de IA](es/ai-providers.md) — Conecta claves de OpenAI y Anthropic y elige modelos por agente.
+- [Herramientas personalizadas](es/custom-tools.md) — Permite que los agentes llamen endpoints HTTP y servidores MCP durante una conversación.
+
+**Canales**
+
+- [WhatsApp](es/whatsapp.md) — Vincula un número por cliente con el puente de Baileys y pasa a control humano.
+- [API de WhatsApp Cloud](es/whatsapp-cloud-api.md) — Conecta un número por la API Cloud oficial de Meta: app, token, webhook y salida a producción.
+- [Widget de chat web](es/web-widget.md) — Integra un agente en cualquier sitio web con un único snippet.
+
+**Operación**
+
+- [Bandeja de entrada](es/inbox.md) — Busca, filtra y toma el control de conversaciones de IA a humano.
+- [Portal del cliente y dominios](es/client-portal.md) — Dale a cada cliente un portal con su marca en su propio dominio.
+- [Panel](es/dashboard.md) — Actividad, agentes destacados y uso de tokens por modelo.
+- [Notificaciones push](es/push-notifications.md) — La costura de proveedores para push móvil: qué trae, qué cuesta y cómo registrar uno.
+
+**Autoalojamiento**
+
+- [Autoalojamiento](es/self-hosting.md) — Despliega en un servidor, respalda datos, actualiza y resuelve problemas.
+- [Contribuir](es/contributing.md) — Ejecuta el proyecto en local, las suites de pruebas y las convenciones.

--- a/docs/en/agents.md
+++ b/docs/en/agents.md
@@ -1,0 +1,59 @@
+# Agents
+
+> Leer en español: [agents.md](../es/agents.md)
+
+An agent is the AI assistant that talks to your end users. Every agent belongs to a single client, and each agent carries its own instructions, model choice, knowledge and multimodal settings. This page covers how to create one and what each setting does.
+
+## What an agent is
+
+An agent lives under a client (`Agency → Client → Agent`), so all the client's context is available to every agent it owns. An agent defines how it should behave, which provider and model answer its messages, how much conversation history it remembers, and whether it can understand incoming images and audio. You can create as many agents per client as you need — for example one for WhatsApp and another embedded as a web widget.
+
+## Creating an agent with the wizard
+
+New agents are created through a five-step wizard (**Agents → New agent**):
+
+1. **Template** — pick an industry starter template or start blank. Templates pre-fill the description, instructions and personality so you have a working prompt from the first minute.
+2. **Identity** — choose the owning client, name the agent and write a short description.
+3. **Prompt** — write the instructions and personality. A live token counter estimates the size of the prompt as you type.
+4. **Model** — set the timezone, provider and model, and tune temperature, max tokens and memory. A context-window bar shows how much of the model's window the prompt uses.
+5. **Review** — confirm the summary and create the agent.
+
+The built-in starter templates are Restaurant orders, Real estate leads, Clinic appointments, Online store support and Customer support. After creation you can refine every field, plus the structured business brief, on the agent detail page.
+
+## Choosing a provider and model
+
+Each agent uses one provider — `openai` or `anthropic` — and one model from that provider. The agency's stored API key for that provider is used, so add your keys first. See [AI providers](ai-providers.md) for the available models and how keys are configured. The model field accepts a custom value if you run a model that isn't in the preset list.
+
+## Multimodal capabilities
+
+An agent can optionally understand incoming media. Each capability has its own toggle and its own model setting, independent of the main chat model:
+
+- **Image recognition (vision)** — when `image_enabled` is on, inbound images are described by the model in `image_model` before reaching the agent.
+- **Audio transcription** — when `audio_enabled` is on, inbound audio is transcribed by the model in `audio_model` (default `whisper-1`) before reaching the agent.
+
+Both features use OpenAI models, so they require an OpenAI key regardless of the agent's chat provider.
+
+## Agent settings
+
+| Setting | Field | What it does |
+| --- | --- | --- |
+| Client | `client_id` | The client that owns the agent. |
+| Instructions | `instructions` | The main behavior brief sent as the system prompt. |
+| Personality | `personality` | Tone and style guidance for replies. |
+| Business brief | `brief_summary`, `brief_products`, `brief_audience`, `brief_policies`, `brief_goal`, `brief_dos`, `brief_donts` | Optional guided fields composed into the system prompt alongside the instructions. |
+| Per-agent context | `manual_context` | Free-form context specific to this agent, saved separately on the detail page. |
+| Per-client context | `general_context` (on the client) | Shared context injected into every agent of that client. |
+| Timezone | `timezone` | IANA timezone (e.g. `America/Bogota`) injected so the agent knows the local date and time. Defaults to `UTC`. |
+| Provider | `provider` | `openai` or `anthropic`. |
+| Model | `model` | The chat model used for replies. |
+| Temperature | `temperature` | Sampling randomness, `0.0`–`2.0` (default `0.7`). |
+| Max tokens | `max_tokens` | Maximum tokens per reply, `1`–`32000` (default `2048`). |
+| Memory limit | `memory_limit` | How many past messages are kept as conversation memory, `0`–`200` (default `30`). |
+| Image recognition | `image_enabled`, `image_model` | Enable vision and pick the model that describes inbound images. |
+| Audio transcription | `audio_enabled`, `audio_model` | Enable transcription and pick the model that transcribes inbound audio (default `whisper-1`). |
+
+Sampling parameters are applied best-effort; models that reject a value fall back to their own defaults.
+
+## Knowledge in the system prompt
+
+Beyond these settings, the agent's Q&A pairs, uploaded documents, per-client context and per-agent context are all assembled into the system prompt at answer time. See [Knowledge base](knowledge-base.md) for how documents are chunked, embedded and retrieved.

--- a/docs/en/ai-providers.md
+++ b/docs/en/ai-providers.md
@@ -1,0 +1,51 @@
+# AI providers
+
+> Leer en español: [ai-providers.md](../es/ai-providers.md)
+
+OpenLivery does not ship with an AI provider of its own. Instead, each agency brings its own key: you paste an API key for a supported provider, OpenLivery stores it encrypted, and every agent under that agency uses it to talk to a model. This keeps you in control of billing, quotas and data.
+
+## Bring your own key
+
+Keys are configured per agency, one key per provider. Open **Settings**, find the provider card and paste your key. When you save it, OpenLivery first validates the key against the provider (it lists `{base_url}/models`); if the check fails, nothing is stored. Only after a successful validation is the key persisted.
+
+Stored keys are never returned to the browser in full — the UI only shows a masked value. On disk, the key is encrypted with a key derived from `ENCRYPTION_KEY` and decrypted on demand when an agent needs it, so rotating or losing that secret makes every stored key unreadable. See [Configuration](configuration.md) for how `ENCRYPTION_KEY` is set and why it must never change.
+
+## Supported providers
+
+Two providers are supported out of the box, each with a fixed base URL:
+
+| Provider | Base URL | Example models |
+| --- | --- | --- |
+| OpenAI | `https://api.openai.com/v1` | `gpt-5.6-sol`, `gpt-5.4-mini`, `gpt-4.1` |
+| Anthropic | `https://api.anthropic.com/v1` | `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
+
+OpenAI keys are sent as a bearer token; Anthropic keys use the `x-api-key` header with the `anthropic-version` header. Under the hood OpenLivery calls the OpenAI Responses API and the Anthropic Messages API.
+
+### Any OpenAI-compatible endpoint
+
+The `base_url` and `model` are per-connection settings, so any OpenAI-compatible endpoint works. Connection testing simply performs a `GET` on `{base_url}/models` and reports how many models the key can see. As long as your endpoint speaks the OpenAI (or Anthropic) API and exposes a `/models` list, you can point OpenLivery at it.
+
+## Model presets
+
+The Settings UI and the agent wizard offer preset model lists so you don't have to memorize IDs. These come straight from `apps/web/lib/providers.ts`.
+
+**OpenAI:** `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`.
+
+**Anthropic:** `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`.
+
+### Vision and audio models
+
+Some capabilities use dedicated model sets rather than the chat model:
+
+- **Vision (`IMAGE_MODELS`)** for image understanding: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-5.5`, `gpt-5.4`, `gpt-5`, `gpt-5-mini`.
+- **Transcription (`AUDIO_MODELS`)** for audio understanding: `gpt-transcribe`, `whisper-1`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-transcribe-diarize`.
+
+## Choosing a model per agent
+
+The provider key is set once per agency, but each agent picks its own provider and model. You do this when you create or edit an agent, choosing from the presets above (or typing a custom ID for a compatible endpoint). See [Agents](agents.md) for how model choice, instructions and knowledge come together.
+
+## Next steps
+
+- [Agents](agents.md) — pick a model and write instructions.
+- [Configuration](configuration.md) — `ENCRYPTION_KEY` and other secrets.
+- [Knowledge base](knowledge-base.md) — give an agent context, Q&A and PDFs.

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -1,0 +1,65 @@
+# Architecture
+
+> Leer en español: [architecture.md](../es/architecture.md)
+
+OpenLivery is a multi-tenant platform: three application services plus PostgreSQL, served through a single-origin gateway. This page explains how the pieces fit together, how the data is shaped, and how tenants stay isolated from one another.
+
+## The services
+
+The stack is four containers orchestrated by Docker Compose. Three of them are application code; the fourth is the database.
+
+| Service | Path | Stack | Role |
+| --- | --- | --- | --- |
+| Backend | `apps/api/` | FastAPI (Python 3.12), SQLAlchemy, Alembic | REST API, auth, AI orchestration, knowledge retrieval |
+| Frontend | `apps/web/` | Next.js (App Router), React, TypeScript, Tailwind | Dashboard, playground, client portal, web widget |
+| WhatsApp bridge | `apps/whatsapp/` | Node.js over Baileys | Holds live WhatsApp sessions, relays messages |
+| Database | — | PostgreSQL | Single source of truth for all state |
+
+## The gateway
+
+Everything is served from one origin by a Caddy gateway (`docker/Caddyfile`). It routes `/api/*` to the backend and everything else to the frontend:
+
+```caddyfile
+:80 {
+	handle /api/* {
+		reverse_proxy api:8000
+	}
+	handle {
+		reverse_proxy web:3000
+	}
+}
+```
+
+Because the app is single-origin, the browser talks to a relative `/api` path and no CORS is needed for the normal flow. TLS is not bundled — put your own reverse proxy in front of the gateway port. See [Self-hosting](self-hosting.md) for the production setup.
+
+## The data model
+
+Every record hangs off an agency. The hierarchy, as defined in `apps/api/app/models.py`:
+
+```text
+Agency
+├── User            (agency staff, login accounts)
+├── ProviderCredential  (one encrypted AI key per provider)
+└── Client
+    ├── Agent
+    │   ├── KnowledgeDocument → KnowledgeChunk
+    │   ├── AgentQA           (question/answer pairs)
+    │   └── Conversation → Message
+    └── WhatsAppChannel  (one per client, bound to an agent)
+```
+
+A `Conversation` records its `channel` (playground, widget or WhatsApp) and a `mode` (`ai` or `human`); switching to `human` pauses the AI so an operator can answer from the inbox. Messages store their role, content and any knowledge `sources` used. See [Agents](agents.md) for how an agent's instructions, brief and knowledge compose into the prompt.
+
+## Tenant isolation
+
+The agency is the tenant boundary. `Agency`, `User`, `Client`, `Agent`, `WhatsAppChannel`, `Conversation` and other tables all carry an indexed `agency_id`, and every authenticated router query filters by the caller's `agency_id`. Deleting an agency cascades to everything it owns. Any new endpoint must preserve this filter.
+
+## Encryption at rest
+
+Sensitive values never hit the database in plaintext. AI provider API keys (`ProviderCredential.encrypted_api_key`) and WhatsApp session state (`WhatsAppChannel.encrypted_auth_state`, `encrypted_qr`) are encrypted with Fernet, using a key derived from `ENCRYPTION_KEY` (`apps/api/app/security.py`). This value must never change once secrets are stored, or they can no longer be decrypted. Passwords are hashed with bcrypt. See [Configuration](configuration.md).
+
+## Runtime behavior
+
+- **Migrations on start** — the backend runs `alembic upgrade head` before accepting traffic, so the schema is always current. Schema changes require a new Alembic migration.
+- **Stateful bridge** — the WhatsApp bridge (`apps/whatsapp/src/manager.ts`) keeps live Baileys sockets in memory and reloads enabled sessions on startup from the encrypted state in PostgreSQL. Backend and bridge authenticate to each other with `WHATSAPP_BRIDGE_TOKEN`. See [WhatsApp](whatsapp.md).
+- **Rate limiting** — public, unauthenticated endpoints are throttled per IP by an in-memory limiter (`apps/api/app/ratelimit.py`), keyed on the client address from `X-Forwarded-For`.

--- a/docs/en/client-portal.md
+++ b/docs/en/client-portal.md
@@ -1,0 +1,53 @@
+# Client portal & domains
+
+> Leer en español: [client-portal.md](../es/client-portal.md)
+
+Each client gets its own portal: a separate login and a focused inbox where they can read conversations and take over from the AI, without ever seeing your agency dashboard. Optionally, you can serve that portal on the client's own custom domain with automatic HTTPS.
+
+## The client portal
+
+The portal is a self-contained space scoped to a single client. It has its own login (separate from your agency account) and shows only that client's agents and conversations — the same inbox your operators use, but limited to one client. From there the client can switch a conversation to `human` mode to pause the AI and reply themselves.
+
+The portal is disabled by default. You enable it per client from the client's settings, and it becomes reachable only once a login email and password are set.
+
+## Portal settings
+
+On a client you configure these fields:
+
+- **`portal_enabled`** — the toggle that turns the portal on. It cannot be enabled until a `portal_email` and a password are set.
+- **`portal_slug`** — the URL segment for the portal (e.g. `acme` → `/portal/acme`). It is generated from the client name on creation, must be unique, and is normalized to a slug when you change it.
+- **`portal_title`** — the heading shown on the portal login and inbox. If left empty it falls back to `"<Client name> Inbox"`.
+- **`portal_email`** — the address the client signs in with.
+- **`portal_password`** — the client's password (minimum 8 characters). It is stored hashed; the API only reports whether one is configured, never the value.
+
+Enabling the portal without both an email and a password is rejected.
+
+## Portal URL
+
+Every enabled portal is served at:
+
+```
+/portal/<slug>
+```
+
+For example, a client with slug `acme` on a stack at `https://app.example.com` reaches its portal at `https://app.example.com/portal/acme`. The portal login, inbox and conversation views all live under this path.
+
+## Custom per-client domain (optional)
+
+Instead of the shared `/portal/<slug>` path, you can point the portal at a domain the client owns, such as `support.acme.com`, with a certificate issued automatically.
+
+### Add a custom domain
+
+1. In the client's settings, set the custom domain (e.g. `support.acme.com`). Saving it resets verification and issues a fresh challenge token.
+2. Create a DNS **TXT** record at `_openlivery-challenge.<domain>` with the token value shown in the settings.
+3. Click **Verify**. OpenLivery resolves the TXT record; once it matches the token, the domain is marked verified.
+4. Point the domain itself at your server (an A/AAAA or CNAME record for `support.acme.com`).
+5. Make sure the on-demand TLS gateway is enabled (see below) — the certificate is then obtained automatically on the first request.
+
+### How it works
+
+- The public, unauthenticated endpoint `GET /api/public/portal-domain?domain=<host>` maps a host to its portal. It returns `{ "portal_slug": ... }` only when the domain matches a client that is verified and enabled, and a non-2xx otherwise.
+- The Next.js `proxy.ts` resolves the incoming host against that endpoint and rewrites a verified host to `/portal/<slug>`, so the browser URL stays on the client's own domain. It reaches the API server-side through `BACKEND_INTERNAL_URL` — see [Configuration](configuration.md).
+- `docker/Caddyfile.ondemand` gates on-demand TLS with the same endpoint as its `ask` hook, so a certificate is issued only for verified portal domains and never for arbitrary hosts pointed at the server.
+
+The on-demand gateway is opt-in. See [Self-hosting](self-hosting.md) for mounting the override and publishing ports 80 and 443.

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -1,0 +1,58 @@
+# Configuration
+
+> Leer en español: [configuration.md](../es/configuration.md)
+
+OpenLivery is configured through environment variables. In Docker, they all live in a single `.env.docker` file at the repository root; a helper script generates it with strong random secrets so you never have to invent them yourself.
+
+## The .env.docker file
+
+Run the generator once per clone:
+
+```bash
+./scripts/generate-docker-env.sh   # writes .env.docker, refuses to overwrite an existing one
+```
+
+It creates the file with restrictive permissions (`umask 077`) and fills the sensitive values with `openssl rand`: a Postgres password, `SECRET_KEY`, `ENCRYPTION_KEY` and `WHATSAPP_BRIDGE_TOKEN`. Compose reads this file (`docker compose --env-file .env.docker`, which `make` does for you). The file is gitignored — keep it out of version control and back it up somewhere safe.
+
+For a non-Docker local setup, the same variables go in a `.env` at the repo root or in `apps/api/.env`; see `.env.example`.
+
+## Key variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `DATABASE_URL` | SQLAlchemy connection string. In Docker it is assembled from `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` pointing at the `db` service | local Postgres |
+| `SECRET_KEY` | Signs the JWT session tokens. Rotating it logs everyone out | dev placeholder |
+| `ENCRYPTION_KEY` | Encrypts AI API keys and WhatsApp session state before they hit the database | dev placeholder |
+| `ACCESS_TOKEN_MINUTES` | Session lifetime | `10080` (7 days) |
+| `COOKIE_SECURE` | Send the session cookie only over HTTPS. Set `true` in production | `false` |
+| `COOKIE_SAMESITE` | Cookie SameSite policy. Use `none` when the frontend and API are on different sites (requires `COOKIE_SECURE=true`) | `lax` |
+| `RATE_LIMIT_ENABLED` | Per-IP rate limiting on public endpoints (auth, portal login, widget) | `true` |
+| `FRONTEND_URL` | Origin allowed by CORS | `http://localhost:3000` |
+| `WHATSAPP_BRIDGE_TOKEN` | Shared secret authenticating backend ↔ WhatsApp bridge calls. Use the same value on both | random |
+| `NEXT_PUBLIC_API_URL` | Public API origin baked into the frontend at build time. Leave empty to use the same origin via the gateway | empty |
+| `BACKEND_INTERNAL_URL` | How the web container reaches the API server-side (used by `proxy.ts` for custom portal domains) | `http://api:8000` |
+
+### The ENCRYPTION_KEY warning
+
+`ENCRYPTION_KEY` must **never** change once secrets have been stored. It derives the key that decrypts every saved AI API key and WhatsApp session. If you rotate or lose it, those secrets become unrecoverable — you will have to re-enter API keys and re-link WhatsApp numbers. Treat it as permanent for the lifetime of your database.
+
+## Host ports
+
+Compose binds each service to a host port, all overridable. Pass them inline to `make up`:
+
+```bash
+API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up
+```
+
+| Variable | What it controls | Default |
+| --- | --- | --- |
+| `WEB_PORT` | The gateway port — this is the app | `3000` |
+| `API_PORT` | Backend, exposed locally for OpenAPI docs and tooling | `8000` |
+| `DB_PORT` | PostgreSQL | `5432` |
+| `BIND_HOST` | Interface to bind to: `127.0.0.1` for local only, `0.0.0.0` to expose on a server | `127.0.0.1` |
+
+The WhatsApp bridge listens on `3101` but is not published to the host in Docker.
+
+## The single-origin gateway
+
+A Caddy container (`docker/Caddyfile`) fronts the whole stack on one origin. It routes `/api/*` to the backend and everything else to the frontend, so the browser talks to a single port and `NEXT_PUBLIC_API_URL` can stay empty. The stack serves plain HTTP only — put your own reverse proxy in front of the gateway for TLS in production. See [Self-hosting](self-hosting.md) for a public deployment.

--- a/docs/en/contributing.md
+++ b/docs/en/contributing.md
@@ -1,0 +1,96 @@
+# Contributing
+
+> Leer en español: [contributing.md](../es/contributing.md)
+
+Docker is the fastest way to run OpenLivery, but for day-to-day development you usually want each service running on the host with hot reload. This guide covers running the backend, frontend and WhatsApp bridge locally, the test suites, migrations and the project conventions.
+
+## Prerequisites
+
+Clone the repository and enable the pre-commit guard once per clone:
+
+```bash
+git clone https://github.com/sarrazola/openlivery.git
+cd openlivery
+git config core.hooksPath .githooks
+```
+
+The guard (`.githooks/pre-commit`) blocks committing local-only files and any staged content flagged as internal. You need Python 3.12, Node.js, and a running PostgreSQL instance the backend can connect to.
+
+## Backend (apps/api)
+
+Copy `.env.example` to `.env` and point `DATABASE_URL` at your PostgreSQL. Install dependencies, apply migrations, then start the server with reload:
+
+```bash
+cd apps/api
+pip install -r requirements.txt
+alembic upgrade head            # migrations must run before starting
+uvicorn app.main:app --reload --port 8000
+```
+
+OpenAPI docs are served at [http://localhost:8000/docs](http://localhost:8000/docs).
+
+## Frontend (apps/web)
+
+```bash
+cd apps/web
+npm install
+npm run dev                     # http://localhost:3000
+```
+
+Use `npm run lint` before committing and `npm run build` to verify a production build. Note that this is Next.js 16 (App Router) — check the docs bundled under `node_modules/next/dist/docs/` before writing non-trivial Next.js code, as several APIs differ from earlier versions.
+
+## WhatsApp bridge (apps/whatsapp)
+
+```bash
+cd apps/whatsapp
+npm install
+npm run dev                     # tsx watch, listens on :3101
+```
+
+Run `npm test` for the test suite and `npm run build` to typecheck with `tsc`.
+
+## Tests
+
+The backend tests need a **separate** database — never point them at your dev DB. They default to `openlivery_test` on localhost and create/drop all tables per test. Override the target with `TEST_DATABASE_URL`:
+
+```bash
+cd apps/api
+pytest -q
+TEST_DATABASE_URL=postgresql+psycopg://user:pass@localhost:5432/openlivery_test pytest -q
+```
+
+Run a single test by node id:
+
+```bash
+pytest tests/test_flows.py::test_register_login_logout_and_me -v
+```
+
+## Database migrations
+
+Any schema change requires a new Alembic migration — Docker runs `alembic upgrade head` on backend start, so a change without a migration will break the containerized stack. Generate one after editing the models, review the generated file, then apply it.
+
+## Conventions
+
+All code, identifiers, comments, commit messages and docs are written in **English**, always. The only thing localized is the end-user UI, through the typed i18n system in `apps/web/lib/i18n` (English default, Spanish for now). Never introduce non-English in code or docs — put user-facing copy behind i18n keys instead.
+
+## Command reference
+
+| Service | Command | What it does |
+| --- | --- | --- |
+| Backend | `pip install -r requirements.txt` | Install Python dependencies |
+| Backend | `alembic upgrade head` | Apply pending migrations |
+| Backend | `uvicorn app.main:app --reload --port 8000` | Run the API with hot reload |
+| Backend | `pytest -q` | Run the test suite |
+| Frontend | `npm install` | Install dependencies |
+| Frontend | `npm run dev` | Run the dev server on :3000 |
+| Frontend | `npm run lint` | Lint with ESLint |
+| Frontend | `npm run build` | Production build |
+| WhatsApp | `npm run dev` | Run the bridge on :3101 |
+| WhatsApp | `npm test` | Run the test suite |
+| WhatsApp | `npm run build` | Typecheck with tsc |
+
+## Next steps
+
+- [Architecture](architecture.md) — how the services fit together.
+- [Configuration](configuration.md) — environment variables, secrets and ports.
+- [Self-hosting](self-hosting.md) — deploy to a public server with TLS and backups.

--- a/docs/en/custom-tools.md
+++ b/docs/en/custom-tools.md
@@ -1,0 +1,49 @@
+# Custom tools
+
+> Leer en español: [custom-tools.md](../es/custom-tools.md)
+
+Custom tools let an agent act, not just answer. From the **Tools** tab of the agent editor you can connect two kinds of tools, and the agent decides when to call them during a conversation: **HTTP tools** (an endpoint of your own or any REST API) and **MCP servers** (external services that speak the Model Context Protocol). Tools work on every channel: the playground, the web widget and WhatsApp.
+
+## HTTP tools
+
+An HTTP tool describes one endpoint the agent may call:
+
+- **Tool name** — `snake_case`, used as the function name the model sees (for example `check_order`). Consecutive underscores are not allowed.
+- **Endpoint URL and method** — the URL may contain `{param}` placeholders (for example `https://api.example.com/orders/{order_id}`); each placeholder automatically becomes a required input the model must provide. Methods: GET, POST, PUT, PATCH or DELETE.
+- **Prompt instructions** — tell the agent when and how to use the tool. This text is appended to the tool description the model sees, so be specific about the conditions and the data required.
+- **Body and query parameters** — each parameter has a name, a type (`string`, `number`, `integer`, `boolean`), a description and a required flag. Body parameters are only allowed on POST, PUT and PATCH.
+- **Advanced options** — auth headers (for example `Authorization: Bearer …`) and a timeout between 1 and 120 seconds (default 30). Header values are **encrypted at rest** and never returned by the API or shown in the UI again; you can only replace them.
+
+When the model calls the tool, OpenLivery substitutes the path placeholders, sends the declared query parameters and JSON body, and returns the response to the model as `HTTP <status>: <body>`. Responses are capped at 100 KB.
+
+## MCP servers
+
+An MCP server connects the agent to every tool that server exposes:
+
+- **Server name** — `snake_case`, up to 24 characters. The server's tools are exposed to the model as `<server>__<tool>` (for example `weather__get_forecast`), which keeps names collision-free across servers.
+- **Server URL and transport** — Streamable HTTP or SSE.
+- **Auth headers** — optional, encrypted at rest like HTTP tool headers.
+
+Before you can save a server you must run **Test connection**, which connects, performs the MCP handshake and lists the server's tools. The discovered list is cached on save and reused at chat time, so conversations never wait on discovery; editing the URL, transport or headers re-runs the check. Creating or updating a server whose connection fails is rejected.
+
+## How tool calling works
+
+When an agent with enabled tools receives a message, OpenLivery sends the tool definitions to the model along with the conversation. If the model decides to call a tool, OpenLivery executes it (the HTTP request, or a call proxied to the MCP server), feeds the result back, and lets the model continue — up to **5 rounds** per reply, after which the model must answer with text. Works with both providers: OpenAI (Responses API) and Anthropic (Messages API). Token usage across all rounds is summed into the reply's usage record.
+
+Every assistant reply stores which tools ran, with their arguments and a preview of each result. In the playground you will see a chip under the reply listing the tools used; failed calls are highlighted and show the error detail, so you can diagnose a broken tool without reading logs.
+
+If a tool call fails, the agent is instructed to tell the user the information or action is not available right now — it will not silently answer from its own knowledge.
+
+## Security
+
+- **Private networks are blocked by default.** HTTP tool URLs that resolve to private, loopback or reserved addresses (including cloud metadata endpoints) are rejected at request time. Self-hosted deployments that need tools against internal services can opt out with `TOOLS_ALLOW_PRIVATE_URLS=true`.
+- **Redirects are never followed.** A 3xx response counts as a failed call, since the data was not retrieved and following redirects blindly would bypass the address check.
+- **Secrets stay encrypted.** Auth headers are encrypted with the same `ENCRYPTION_KEY` used for provider keys (see [Configuration](configuration.md)) and are never sent back to the browser.
+
+## Troubleshooting
+
+- **"Could not connect to the MCP server"** — the message includes the cause: rejected credentials (check the `Authorization` header format, usually `Bearer <token>`), unreachable host, timeout, or an endpoint that does not answer like an MCP server (check the URL and transport).
+- **The agent never calls the tool** — make the prompt instructions concrete ("Use when the customer asks about an order status"), check the tool's toggle is enabled, and mention the data in your test message ("what's the status of order 42?").
+- **A working tool suddenly fails** — the target API may have moved behind a redirect or changed auth. The playground error detail shows the exact status the tool received.
+
+See [Agents](agents.md) for the rest of the agent editor and [AI providers](ai-providers.md) for connecting a model that supports tool calling.

--- a/docs/en/dashboard.md
+++ b/docs/en/dashboard.md
@@ -1,0 +1,38 @@
+# Dashboard
+
+> Leer en español: [dashboard.md](../es/dashboard.md)
+
+The dashboard is your agency's home screen — the first thing you see after signing in. It summarises activity across every client, agent and channel in one place, and adapts to a date range you pick.
+
+## Date range
+
+A selector in the top-right controls the window used by the charts and counters. The options are **7, 14, 30 and 90 days**, defaulting to 14. Changing it refetches the metrics for the new window.
+
+## Next steps
+
+Until your workspace is set up, an onboarding checklist walks you through the first tasks: create a client, create an agent, and connect a channel. The first two steps tick themselves off automatically once you have at least one client and one agent.
+
+## Headline metrics
+
+Four cards sit at the top, each showing a total plus a secondary line:
+
+- **Clients** — total clients, with how many are active.
+- **Agents** — total agents, with how many are active.
+- **Conversations** — total conversations across all channels.
+- **Channels** — total WhatsApp channels, with how many are connected.
+
+## Activity
+
+The activity panel plots **new conversations per day** over the selected window as a bar chart (zero-filled, so every day appears even with no traffic). Alongside it, two counters cover the same window: total **messages**, and conversations **handled by a human** — those switched to human mode so an operator answers from the inbox. See [Inbox](inbox.md).
+
+## Top agents
+
+A ranked list shows your busiest agents by conversation count for the window, up to five. Each row links straight to that agent. See [Agents](agents.md).
+
+## Token usage by model
+
+This panel breaks down consumption by model over the window, up to six models, sorted by total tokens. Each row shows the model name and a bar for its total, and the panel header shows aggregate **input** (↓) and **output** (↑) tokens for the whole window. This reflects real usage recorded per request, so it stays empty until your agents start replying.
+
+## Recent agents
+
+At the bottom, the five most recently created agents are listed with their client and status, plus a link to the full [Agents](agents.md) list.

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -1,0 +1,60 @@
+# Getting started
+
+> Leer en español: [getting-started.md](../es/getting-started.md)
+
+OpenLivery runs as three services plus PostgreSQL, orchestrated by Docker Compose. The fastest way to try it is to clone the repository, generate secrets and bring the stack up with a single command.
+
+## Requirements
+
+You need [Docker](https://docs.docker.com/get-docker/) — Docker Desktop, or Docker Engine with the Compose plugin. Nothing else is installed on the host; every service (frontend, backend, WhatsApp bridge and database) runs in a container.
+
+## Install and run
+
+```bash
+git clone https://github.com/sarrazola/openlivery.git
+cd openlivery
+./scripts/generate-docker-env.sh   # writes .env.docker with random secrets (gitignored)
+make up                            # build images, start services, run migrations
+```
+
+`make up` wraps Docker Compose: it builds the images, starts the four services and applies the database migrations before the API accepts traffic.
+
+## Open the app
+
+Once the stack is healthy:
+
+- **App** — [http://localhost:3000](http://localhost:3000)
+- **API docs (OpenAPI)** — [http://localhost:8000/docs](http://localhost:8000/docs)
+
+If those ports are already in use, override them inline:
+
+```bash
+API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up
+```
+
+Prefer not to build locally? `make pull` runs the prebuilt images published to GHCR instead of building from source.
+
+## First steps
+
+1. **Create your agency** on the first screen — this is the top-level workspace that owns everything else.
+2. Open **Settings** and add an OpenAI and/or Anthropic API key. The key is verified when you save it. See [AI providers](ai-providers.md).
+3. Create a **client**, then an **agent** for that client: pick a provider and model and write the agent's instructions. See [Agents](agents.md).
+4. Add knowledge (context, Q&A pairs, PDFs) and optionally enable image or audio understanding. See [Knowledge base](knowledge-base.md).
+5. Open the **Playground** to chat with the agent, then connect a [WhatsApp](whatsapp.md) number or embed the [web widget](web-widget.md).
+
+## Useful commands
+
+| Command | What it does |
+| --- | --- |
+| `make up` | Build, start and migrate the whole stack |
+| `make down` | Stop and remove the containers |
+| `make logs` | Follow logs from all services |
+| `make migrate` | Apply pending database migrations |
+| `make test` | Run the backend test suite |
+| `make help` | List every available target |
+
+## Next steps
+
+- [Configuration](configuration.md) — environment variables, secrets and ports.
+- [Architecture](architecture.md) — how the services fit together.
+- [Self-hosting](self-hosting.md) — deploy to a public server with TLS and backups.

--- a/docs/en/inbox.md
+++ b/docs/en/inbox.md
@@ -1,0 +1,36 @@
+# Inbox
+
+> Leer en español: [inbox.md](../es/inbox.md)
+
+The Inbox is a single place to watch every conversation your agents are having, search across them, and step in as a human when the AI needs help. It pulls together conversations from every channel — the playground, [WhatsApp](whatsapp.md) and the [web widget](web-widget.md) — into one list.
+
+## Unified list
+
+Every conversation shows the contact name (or title), a preview of the latest message, the agent that owns it, the channel it came from, and a badge marking whether it is in **AI** or **human** mode. The list is scoped to your agency, so operators only see their own tenant's conversations.
+
+Two filters at the top narrow the view: by **agent** and by **channel** (playground, WhatsApp or widget). These combine with the tabs and search below.
+
+## Search and tabs
+
+A search box runs **server-side**: it matches the conversation title, the contact name, and the content of the latest message. Input is debounced, so results update shortly after you stop typing.
+
+Four tabs filter the list:
+
+- **All** — every conversation.
+- **Unread** — conversations whose latest message is from the visitor and hasn't been read since.
+- **Human** — conversations currently in human mode.
+- **AI** — conversations currently handled by the agent.
+
+## Unread tracking and pagination
+
+Unread is derived from an `operator_read_at` timestamp: a conversation counts as unread when its last message came from the visitor and arrived after you last opened it. Opening a conversation marks it read. The first page refreshes automatically every few seconds so new messages surface without a manual reload. The list loads in pages of 30 and fetches more as you scroll toward the bottom.
+
+## Human takeover
+
+Each conversation carries a `mode` field. In **AI** mode the agent answers automatically. Use **Take control** to switch the conversation to **human** mode: this pauses the AI so an operator can reply in its place. While a conversation is in human mode the AI will not generate replies — attempts to do so are rejected until you hand it back. When you're done, **Return to AI** flips the mode back and the agent resumes.
+
+This is the same `mode` concept used for [WhatsApp](whatsapp.md) conversations, so taking over works consistently regardless of channel.
+
+## Who can take over
+
+Both agency operators (from this Inbox) and client users can take over conversations. Client users do it from the [client portal](client-portal.md), which exposes the same take-control and reply-as-human actions scoped to their client.

--- a/docs/en/knowledge-base.md
+++ b/docs/en/knowledge-base.md
@@ -1,0 +1,42 @@
+# Knowledge base
+
+> Leer en español: [knowledge-base.md](../es/knowledge-base.md)
+
+The knowledge base is how you give an agent the business facts it needs to answer accurately. You add knowledge from three kinds of sources, and OpenLivery assembles the relevant parts into the agent's system prompt on every message.
+
+## Sources of knowledge
+
+- **General context** — free-form text about the client (shared across that client's agents) and a per-agent manual context. Use it for anything you can describe in prose: hours, tone, positioning, policies.
+- **Q&A pairs** — structured question/answer entries. These are ideal for frequently asked questions where you want a specific, reliable answer.
+- **PDF uploads** — attach documents (catalogs, manuals, price lists) and the agent reads from their text. PDFs are limited to 20 MB and only PDF files are accepted.
+
+See [Agents](agents.md) for where these live in the agent editor.
+
+## How PDFs are processed
+
+When you upload a PDF, its text is extracted immediately with `pypdf` and stored on the document. If no text can be extracted (for example a scanned, image-only PDF), the document is marked as `error` and is not used. Extracted text is then split into paragraph-sized chunks. When an OpenAI-compatible connection with embedding support is available, each chunk is embedded and the vector is saved alongside it; embedding is best-effort, so if it is unavailable the agent still works using keyword search.
+
+## How retrieval works
+
+On each incoming message, OpenLivery decides how much document text to include:
+
+- **Small knowledge bases are sent in full.** When the combined extracted text of all processed documents is at or below **45,000 characters**, every document is included verbatim — no search step.
+- **Larger knowledge bases are retrieved.** Above that threshold, OpenLivery runs semantic search: it embeds the user's query and ranks stored chunks by cosine similarity, then fills the context up to a search budget. If embeddings are unavailable, it falls back to keyword ranking over the chunks.
+
+Embeddings are stored as a plain **JSON array of floats** and similarity is computed in Python, so **no database extension is required** — the knowledge base is portable across any PostgreSQL. See [AI providers](ai-providers.md) for configuring the connection used for embeddings.
+
+## How the system prompt is assembled
+
+Everything is composed into a single system message, in this order:
+
+1. The agent's identity line (name and client).
+2. The current date and time, in the agent's configured timezone.
+3. Main instructions.
+4. Personality and tone.
+5. The business brief, if filled in.
+6. The client's general context.
+7. The agent's manual context.
+8. Q&A pairs.
+9. Retrieved (or full) PDF knowledge text.
+
+The recent conversation history is appended after this system message. Any empty section is skipped, so the prompt only carries what you have actually provided.

--- a/docs/en/push-notifications.md
+++ b/docs/en/push-notifications.md
@@ -1,5 +1,7 @@
 # Push notifications
 
+> Leer en español: [push-notifications.md](../es/push-notifications.md)
+
 OpenLivery ships the notification *plumbing* and no notification *provider*.
 There is no account to create, no third party involved, and nothing to pay for
 in a default install: `PUSH_PROVIDER` is `none` and the server sends nothing.
@@ -23,7 +25,7 @@ The practical consequence:
   published it. This is Apple's and Google's model, not a limitation we added.
 - **You build the app yourself** under your own bundle identifier and push
   credentials — which the white-label setup already supports, see
-  [`apps/mobile/WHITELABEL.md`](../apps/mobile/WHITELABEL.md). Now push is
+  [`apps/mobile/WHITELABEL.md`](../../apps/mobile/WHITELABEL.md). Now push is
   entirely yours: you pick the provider, you hold the keys, you pay whoever you
   chose (or nobody).
 

--- a/docs/en/self-hosting.md
+++ b/docs/en/self-hosting.md
@@ -3,7 +3,7 @@
 > Leer en español: [self-hosting.md](../es/self-hosting.md)
 
 Run and operate your own OpenLivery instance. For a feature overview see the
-[README](../README.md).
+[README](../../README.md).
 
 OpenLivery is orchestrated by Docker Compose, with a `Makefile` wrapping the
 common commands. A lightweight **gateway** (Caddy) is the single public entry

--- a/docs/en/self-hosting.md
+++ b/docs/en/self-hosting.md
@@ -1,5 +1,7 @@
 # Self-hosting OpenLivery
 
+> Leer en español: [self-hosting.md](../es/self-hosting.md)
+
 Run and operate your own OpenLivery instance. For a feature overview see the
 [README](../README.md).
 
@@ -37,6 +39,7 @@ front of it (see [Go to production](#go-to-production-https)). One instance =
 - [Go to production (HTTPS)](#go-to-production-https)
 - [Environment variables](#environment-variables)
 - [Manage your install](#manage-your-install)
+- [Persistent data](#persistent-data)
 - [Backups](#backups)
 - [Upgrade](#upgrade)
 - [Uninstall](#uninstall)
@@ -44,6 +47,7 @@ front of it (see [Go to production](#go-to-production-https)). One instance =
 - [Connect WhatsApp](#connect-whatsapp)
 - [Tests](#tests)
 - [WhatsApp / Baileys caveats](#whatsapp--baileys-caveats)
+- [Troubleshooting](#troubleshooting)
 
 ## Before you begin
 
@@ -245,6 +249,19 @@ make down                 # stop and remove containers (keeps data volumes)
 
 Run `make help` for the full list.
 
+## Persistent data
+
+All state lives in named Docker volumes, so `make down` and upgrades keep it:
+
+| Volume | Contents |
+| --- | --- |
+| `postgres_data` | The PostgreSQL database — agencies, agents, conversations, encrypted provider keys and encrypted WhatsApp session state. |
+| `backend_storage` | Uploaded files (e.g. knowledge-base PDFs). |
+
+The `ENCRYPTION_KEY` decrypts the provider API keys and WhatsApp sessions.
+**Never change it** once secrets are stored, or they become unrecoverable —
+treat it as part of your backup.
+
 ## Backups
 
 Export PostgreSQL without stopping the app:
@@ -365,3 +382,17 @@ Cloud API, and this project is not affiliated with or endorsed by WhatsApp/Meta.
   groups, statuses, newsletters, documents, locations, reactions and calls.
 - One WhatsApp account belongs to one client; another client needs a different
   number. `apps/whatsapp/package.json` pins an exact Baileys version.
+
+## Troubleshooting
+
+- **Ports already in use.** Override them inline:
+  `API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up`.
+- **A service is unhealthy.** Check its logs with `make logs SERVICE=api` (or
+  `web`, `whatsapp`, `db`) and `make ps` for status.
+- **Session does not persist, or login loops behind HTTPS.** Make sure
+  `COOKIE_SECURE=true` is set and you are reaching the app over TLS.
+- **Provider keys or the WhatsApp session stopped decrypting.** The
+  `ENCRYPTION_KEY` changed — restore the original value from your backup.
+- **WhatsApp asks for a new QR after a restart.** Normal only if WhatsApp ended
+  the session, the device was unlinked or `ENCRYPTION_KEY` changed; otherwise
+  the bridge reloads enabled sessions from PostgreSQL automatically.

--- a/docs/en/web-widget.md
+++ b/docs/en/web-widget.md
@@ -1,0 +1,41 @@
+# Web chat widget
+
+> Leer en español: [web-widget.md](../es/web-widget.md)
+
+The web widget is an embeddable chat, backed by one of your agents, that you can drop onto any website with a single `<script>` tag. Visitors get a floating chat button; opening it talks to the agent through OpenLivery's public API, with the same knowledge and instructions you configured.
+
+## How it works
+
+Each agent has a `widget_public_id` — a public identifier used in the widget route `/widget/<publicId>`. The loader script mounts an `iframe` pointing at that route and adds a floating launcher button. Because the id is public, the widget is served without authentication, so nothing sensitive (API keys, other clients' data) is ever exposed to the browser.
+
+The widget only works while it is enabled: the backend serves the config, history and message endpoints only for agents where `widget_enabled` is on. Publish and enable the agent before embedding.
+
+## Enable and get the snippet
+
+1. Open the agent and go to the **Widget** tab.
+2. Toggle **Enable widget** and set the greeting, color and position (left or right).
+3. Save, then copy the embed snippet from the **Embed** section. A **Preview** link opens the widget standalone.
+
+The snippet points `data-agent` at the agent's public id and passes the appearance options as data attributes:
+
+```html
+<script
+  src="https://your-openlivery-domain/widget.js"
+  data-agent="AGENT_PUBLIC_ID"
+  data-color="#075985"
+  data-position="right"
+  async
+></script>
+```
+
+Paste it before the closing `</body>` tag of any page. The `src` origin must be your OpenLivery deployment; `widget.js` derives the iframe URL from its own origin.
+
+## Messages and rate limiting
+
+When a visitor sends a message, the widget calls the public endpoint `POST /api/widget/<publicId>/messages` with a per-browser `session_id`. The backend finds the agent, appends the message to a `widget` conversation, retrieves knowledge, calls the configured provider and returns the reply. Session history is kept in the visitor's `localStorage` so the conversation survives page reloads.
+
+These public endpoints are rate-limited per client IP (30 message requests per minute) because each call spends LLM tokens. Callers over the limit get `429 Too Many Requests` with a `Retry-After` header. The limiter reads the client IP from `X-Forwarded-For` set by the gateway. See [Configuration](configuration.md) for the `RATE_LIMIT_ENABLED` toggle.
+
+## Widget conversations in the inbox
+
+Every widget chat becomes a conversation on the `widget` channel, so it shows up in the [Inbox](inbox.md) alongside WhatsApp and playground threads. You can filter by the widget channel, read the full transcript, and switch a conversation to **human** mode — which pauses the AI so an operator can reply directly from the portal.

--- a/docs/en/whatsapp-cloud-api.md
+++ b/docs/en/whatsapp-cloud-api.md
@@ -1,6 +1,6 @@
 # Connecting the WhatsApp Business Cloud API
 
-> Leer en español: [whatsapp-cloud-api.es.md](whatsapp-cloud-api.es.md)
+> Leer en español: [whatsapp-cloud-api.md](../es/whatsapp-cloud-api.md)
 
 This guide walks through connecting a client's WhatsApp number to OpenLivery
 using the official **WhatsApp Business Cloud API** (hosted by Meta): from

--- a/docs/en/whatsapp.md
+++ b/docs/en/whatsapp.md
@@ -1,0 +1,44 @@
+# WhatsApp
+
+> Leer en español: [whatsapp.md](../es/whatsapp.md)
+
+OpenLivery connects a real WhatsApp number to each client so their agent answers conversations automatically. Each client gets its own session, linked by scanning a QR code from the WhatsApp mobile app — no WhatsApp Business API account required.
+
+## The bridge service
+
+WhatsApp support runs in a dedicated service, the **bridge** (`apps/whatsapp/`), a stateful Node.js process built on [Baileys](https://github.com/WhiskeySockets/Baileys), the WhatsApp Web protocol. The bridge holds one live socket per connected client and talks to the backend over an internal API.
+
+Because it is stateful, the bridge does not keep sessions in memory only: the encrypted session and auth state is persisted through the backend in PostgreSQL. On startup the bridge calls the backend for the list of enabled channels that already have a saved session and reloads them, so numbers reconnect on their own after a restart.
+
+## Connect a number
+
+One WhatsApp session belongs to one client. To connect it:
+
+1. Open a **client**, go to its **WhatsApp** channel, and pick the agent that should answer incoming messages.
+2. Click connect. The backend asks the bridge to start a session, and a **QR code** appears.
+3. On the phone that owns the number, open WhatsApp and go to **Settings → Linked devices → Link a device**.
+4. Scan the QR code. Once the phone confirms, the channel switches to **connected** and shows the linked number.
+
+The session survives restarts from then on. If the number is unlinked from the phone (or the session is invalidated), the bridge clears the stored auth state and the channel returns to disconnected. You can also disconnect from the same page, which logs the device out and removes the saved session.
+
+## How messages flow
+
+When a contact writes to the number:
+
+1. The bridge receives the message and forwards it to the backend at `POST /api/whatsapp/channels/{channel_id}/inbound`.
+2. The backend records the message on the client's conversation, retrieves the agent's knowledge, and generates a reply with the assigned agent.
+3. The reply is sent back through the bridge to the contact on WhatsApp.
+
+Images and voice notes are forwarded too; when the agent has image or audio understanding enabled they are described or transcribed before reaching the model. See [Knowledge base](knowledge-base.md).
+
+Backend and bridge authenticate every call to each other with a shared secret, `WHATSAPP_BRIDGE_TOKEN`. It is generated for you by the setup script — see [Configuration](configuration.md).
+
+## Human takeover
+
+Every conversation has a `mode`, either `ai` (the default) or `human`. When you switch a conversation to human mode, the AI stops replying to it — the backend still records incoming messages, but generates no automatic answer — so a person can take over and respond directly from the [inbox](inbox.md) or the [client portal](client-portal.md). Switch back to `ai` to hand the conversation to the agent again.
+
+## Other channels
+
+WhatsApp is the only messaging channel in the open-source core today. Instagram and Facebook Messenger are on the roadmap.
+
+Next: manage live conversations in the [inbox](inbox.md), or let clients handle their own in the [client portal](client-portal.md).

--- a/docs/es/agents.md
+++ b/docs/es/agents.md
@@ -1,0 +1,59 @@
+# Agentes
+
+> Read in English: [agents.md](../en/agents.md)
+
+Un agente es el asistente de IA que conversa con tus usuarios finales. Cada agente pertenece a un único cliente, y cada agente lleva sus propias instrucciones, elección de modelo, conocimiento y ajustes multimodales. Esta página cubre cómo crear uno y qué hace cada ajuste.
+
+## Qué es un agente
+
+Un agente vive bajo un cliente (`Agency → Client → Agent`), de modo que todo el contexto del cliente está disponible para cada agente que le pertenece. Un agente define cómo debe comportarse, qué proveedor y modelo responden sus mensajes, cuánto historial de conversación recuerda y si puede entender imágenes y audio entrantes. Puedes crear tantos agentes por cliente como necesites — por ejemplo, uno para WhatsApp y otro incrustado como widget web.
+
+## Crear un agente con el asistente
+
+Los agentes nuevos se crean mediante un asistente de cinco pasos (**Agents → New agent**):
+
+1. **Plantilla** — elige una plantilla inicial por industria o empieza en blanco. Las plantillas rellenan la descripción, las instrucciones y la personalidad para que tengas un prompt funcional desde el primer minuto.
+2. **Identidad** — elige el cliente propietario, nombra el agente y escribe una descripción breve.
+3. **Prompt** — escribe las instrucciones y la personalidad. Un contador de tokens en vivo estima el tamaño del prompt mientras escribes.
+4. **Modelo** — define la zona horaria, el proveedor y el modelo, y ajusta la temperatura, los tokens máximos y la memoria. Una barra de ventana de contexto muestra cuánto de la ventana del modelo usa el prompt.
+5. **Revisión** — confirma el resumen y crea el agente.
+
+Las plantillas iniciales incluidas son Pedidos de restaurante, Leads inmobiliarios, Citas de clínica, Soporte de tienda online y Atención al cliente. Después de crearlo puedes refinar cada campo, además del brief estructurado del negocio, en la página de detalle del agente.
+
+## Elegir proveedor y modelo
+
+Cada agente usa un proveedor — `openai` o `anthropic` — y un modelo de ese proveedor. Se utiliza la clave API almacenada de la agencia para ese proveedor, así que añade tus claves primero. Consulta [Proveedores de IA](ai-providers.md) para ver los modelos disponibles y cómo se configuran las claves. El campo de modelo acepta un valor personalizado si usas un modelo que no está en la lista de presets.
+
+## Capacidades multimodales
+
+Un agente puede, opcionalmente, entender medios entrantes. Cada capacidad tiene su propio interruptor y su propio ajuste de modelo, independiente del modelo de chat principal:
+
+- **Reconocimiento de imágenes (visión)** — cuando `image_enabled` está activo, las imágenes entrantes se describen con el modelo de `image_model` antes de llegar al agente.
+- **Transcripción de audio** — cuando `audio_enabled` está activo, el audio entrante se transcribe con el modelo de `audio_model` (por defecto `whisper-1`) antes de llegar al agente.
+
+Ambas funciones usan modelos de OpenAI, por lo que requieren una clave de OpenAI sin importar el proveedor de chat del agente.
+
+## Ajustes del agente
+
+| Ajuste | Campo | Qué hace |
+| --- | --- | --- |
+| Cliente | `client_id` | El cliente propietario del agente. |
+| Instrucciones | `instructions` | El brief principal de comportamiento enviado como prompt del sistema. |
+| Personalidad | `personality` | Guía de tono y estilo para las respuestas. |
+| Brief del negocio | `brief_summary`, `brief_products`, `brief_audience`, `brief_policies`, `brief_goal`, `brief_dos`, `brief_donts` | Campos guiados opcionales que se componen en el prompt del sistema junto a las instrucciones. |
+| Contexto por agente | `manual_context` | Contexto libre específico de este agente, guardado por separado en la página de detalle. |
+| Contexto por cliente | `general_context` (en el cliente) | Contexto compartido inyectado en cada agente de ese cliente. |
+| Zona horaria | `timezone` | Zona horaria IANA (p. ej. `America/Bogota`) inyectada para que el agente conozca la fecha y hora locales. Por defecto `UTC`. |
+| Proveedor | `provider` | `openai` o `anthropic`. |
+| Modelo | `model` | El modelo de chat usado para las respuestas. |
+| Temperatura | `temperature` | Aleatoriedad del muestreo, `0.0`–`2.0` (por defecto `0.7`). |
+| Tokens máximos | `max_tokens` | Máximo de tokens por respuesta, `1`–`32000` (por defecto `2048`). |
+| Límite de memoria | `memory_limit` | Cuántos mensajes pasados se conservan como memoria de conversación, `0`–`200` (por defecto `30`). |
+| Reconocimiento de imágenes | `image_enabled`, `image_model` | Activa la visión y elige el modelo que describe las imágenes entrantes. |
+| Transcripción de audio | `audio_enabled`, `audio_model` | Activa la transcripción y elige el modelo que transcribe el audio entrante (por defecto `whisper-1`). |
+
+Los parámetros de muestreo se aplican con mejor esfuerzo; los modelos que rechazan un valor recurren a sus propios valores por defecto.
+
+## El conocimiento en el prompt del sistema
+
+Más allá de estos ajustes, los pares de preguntas y respuestas del agente, los documentos subidos, el contexto por cliente y el contexto por agente se ensamblan en el prompt del sistema al momento de responder. Consulta [Base de conocimiento](knowledge-base.md) para ver cómo se fragmentan, se generan embeddings y se recuperan los documentos.

--- a/docs/es/ai-providers.md
+++ b/docs/es/ai-providers.md
@@ -1,0 +1,51 @@
+# Proveedores de IA
+
+> Read in English: [ai-providers.md](../en/ai-providers.md)
+
+OpenLivery no incluye un proveedor de IA propio. En su lugar, cada agencia trae su propia clave: pegas una API key de un proveedor compatible, OpenLivery la guarda cifrada y todos los agentes de esa agencia la usan para hablar con un modelo. Así mantienes el control de la facturación, las cuotas y los datos.
+
+## Trae tu propia clave
+
+Las claves se configuran por agencia, una clave por proveedor. Abre **Settings**, busca la tarjeta del proveedor y pega tu clave. Al guardarla, OpenLivery primero valida la clave contra el proveedor (lista `{base_url}/models`); si la comprobación falla, no se guarda nada. Solo tras una validación correcta se persiste la clave.
+
+Las claves guardadas nunca se devuelven completas al navegador: la interfaz solo muestra un valor enmascarado. En disco, la clave se cifra con una clave derivada de `ENCRYPTION_KEY` y se descifra bajo demanda cuando un agente la necesita, de modo que rotar o perder ese secreto hace ilegibles todas las claves guardadas. Consulta [Configuración](configuration.md) para saber cómo se define `ENCRYPTION_KEY` y por qué nunca debe cambiar.
+
+## Proveedores compatibles
+
+Hay dos proveedores compatibles de fábrica, cada uno con una base URL fija:
+
+| Proveedor | Base URL | Modelos de ejemplo |
+| --- | --- | --- |
+| OpenAI | `https://api.openai.com/v1` | `gpt-5.6-sol`, `gpt-5.4-mini`, `gpt-4.1` |
+| Anthropic | `https://api.anthropic.com/v1` | `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
+
+Las claves de OpenAI se envían como bearer token; las de Anthropic usan la cabecera `x-api-key` junto con la cabecera `anthropic-version`. Internamente OpenLivery llama a la OpenAI Responses API y a la Anthropic Messages API.
+
+### Cualquier endpoint compatible con OpenAI
+
+La `base_url` y el `model` son ajustes por conexión, así que funciona cualquier endpoint compatible con OpenAI. La prueba de conexión simplemente hace un `GET` a `{base_url}/models` e informa cuántos modelos puede ver la clave. Mientras tu endpoint hable la API de OpenAI (o de Anthropic) y exponga una lista `/models`, puedes apuntar OpenLivery hacia él.
+
+## Presets de modelos
+
+La interfaz de Settings y el asistente de agentes ofrecen listas de modelos predefinidas para que no tengas que memorizar IDs. Provienen directamente de `apps/web/lib/providers.ts`.
+
+**OpenAI:** `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`.
+
+**Anthropic:** `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`.
+
+### Modelos de visión y audio
+
+Algunas capacidades usan conjuntos de modelos específicos en lugar del modelo de chat:
+
+- **Visión (`IMAGE_MODELS`)** para entender imágenes: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-5.5`, `gpt-5.4`, `gpt-5`, `gpt-5-mini`.
+- **Transcripción (`AUDIO_MODELS`)** para entender audio: `gpt-transcribe`, `whisper-1`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-transcribe-diarize`.
+
+## Elegir un modelo por agente
+
+La clave del proveedor se define una vez por agencia, pero cada agente elige su propio proveedor y modelo. Lo haces al crear o editar un agente, escogiendo entre los presets anteriores (o escribiendo un ID personalizado para un endpoint compatible). Consulta [Agentes](agents.md) para ver cómo se combinan la elección de modelo, las instrucciones y el conocimiento.
+
+## Siguientes pasos
+
+- [Agentes](agents.md) — elige un modelo y escribe instrucciones.
+- [Configuración](configuration.md) — `ENCRYPTION_KEY` y otros secretos.
+- [Base de conocimiento](knowledge-base.md) — da contexto, Q&A y PDFs a un agente.

--- a/docs/es/architecture.md
+++ b/docs/es/architecture.md
@@ -1,0 +1,65 @@
+# Arquitectura
+
+> Read in English: [architecture.md](../en/architecture.md)
+
+OpenLivery es una plataforma multi-tenant: tres servicios de aplicación más PostgreSQL, servidos a través de una puerta de enlace de origen único. Esta página explica cómo encajan las piezas, cómo se estructuran los datos y cómo se mantiene aislado cada tenant.
+
+## Los servicios
+
+El stack son cuatro contenedores orquestados por Docker Compose. Tres de ellos son código de aplicación; el cuarto es la base de datos.
+
+| Servicio | Ruta | Stack | Rol |
+| --- | --- | --- | --- |
+| Backend | `apps/api/` | FastAPI (Python 3.12), SQLAlchemy, Alembic | API REST, autenticación, orquestación de IA, recuperación de conocimiento |
+| Frontend | `apps/web/` | Next.js (App Router), React, TypeScript, Tailwind | Panel, playground, portal del cliente, widget web |
+| Puente de WhatsApp | `apps/whatsapp/` | Node.js sobre Baileys | Mantiene las sesiones vivas de WhatsApp y retransmite mensajes |
+| Base de datos | — | PostgreSQL | Fuente única de verdad para todo el estado |
+
+## La puerta de enlace
+
+Todo se sirve desde un único origen mediante una puerta de enlace Caddy (`docker/Caddyfile`). Enruta `/api/*` al backend y todo lo demás al frontend:
+
+```caddyfile
+:80 {
+	handle /api/* {
+		reverse_proxy api:8000
+	}
+	handle {
+		reverse_proxy web:3000
+	}
+}
+```
+
+Como la aplicación es de origen único, el navegador habla con una ruta relativa `/api` y no se necesita CORS para el flujo normal. TLS no viene incluido: coloca tu propio proxy inverso delante del puerto de la puerta de enlace. Consulta [Autoalojamiento](self-hosting.md) para la configuración de producción.
+
+## El modelo de datos
+
+Cada registro cuelga de una agencia. La jerarquía, tal como se define en `apps/api/app/models.py`:
+
+```text
+Agency
+├── User            (personal de la agencia, cuentas de acceso)
+├── ProviderCredential  (una clave de IA cifrada por proveedor)
+└── Client
+    ├── Agent
+    │   ├── KnowledgeDocument → KnowledgeChunk
+    │   ├── AgentQA           (pares de pregunta/respuesta)
+    │   └── Conversation → Message
+    └── WhatsAppChannel  (uno por cliente, vinculado a un agente)
+```
+
+Una `Conversation` registra su `channel` (playground, widget o WhatsApp) y un `mode` (`ai` o `human`); cambiar a `human` pausa la IA para que un operador pueda responder desde el inbox. Los mensajes guardan su rol, contenido y las `sources` de conocimiento utilizadas. Consulta [Agentes](agents.md) para ver cómo las instrucciones, el brief y el conocimiento de un agente componen el prompt.
+
+## Aislamiento de tenants
+
+La agencia es la frontera del tenant. Las tablas `Agency`, `User`, `Client`, `Agent`, `WhatsAppChannel`, `Conversation` y otras llevan un `agency_id` indexado, y toda consulta autenticada de los routers filtra por el `agency_id` de quien llama. Eliminar una agencia propaga en cascada a todo lo que le pertenece. Cualquier endpoint nuevo debe preservar este filtro.
+
+## Cifrado en reposo
+
+Los valores sensibles nunca llegan a la base de datos en texto plano. Las claves de API de los proveedores de IA (`ProviderCredential.encrypted_api_key`) y el estado de sesión de WhatsApp (`WhatsAppChannel.encrypted_auth_state`, `encrypted_qr`) se cifran con Fernet, usando una clave derivada de `ENCRYPTION_KEY` (`apps/api/app/security.py`). Este valor nunca debe cambiar una vez que se han almacenado secretos, o dejarán de poder descifrarse. Las contraseñas se hashean con bcrypt. Consulta [Configuración](configuration.md).
+
+## Comportamiento en tiempo de ejecución
+
+- **Migraciones al arrancar** — el backend ejecuta `alembic upgrade head` antes de aceptar tráfico, de modo que el esquema siempre está actualizado. Los cambios de esquema requieren una nueva migración de Alembic.
+- **Puente con estado** — el puente de WhatsApp (`apps/whatsapp/src/manager.ts`) mantiene en memoria los sockets vivos de Baileys y recarga al arrancar las sesiones habilitadas desde el estado cifrado en PostgreSQL. El backend y el puente se autentican entre sí con `WHATSAPP_BRIDGE_TOKEN`. Consulta [WhatsApp](whatsapp.md).
+- **Límite de tasa** — los endpoints públicos y no autenticados se limitan por IP con un limitador en memoria (`apps/api/app/ratelimit.py`), usando como clave la dirección del cliente obtenida de `X-Forwarded-For`.

--- a/docs/es/client-portal.md
+++ b/docs/es/client-portal.md
@@ -1,0 +1,53 @@
+# Portal del cliente y dominios
+
+> Read in English: [client-portal.md](../en/client-portal.md)
+
+Cada cliente tiene su propio portal: un inicio de sesión independiente y una bandeja de entrada enfocada donde puede leer conversaciones y tomar el control de la IA, sin ver nunca el panel de tu agencia. Opcionalmente, puedes servir ese portal en el dominio propio del cliente con HTTPS automático.
+
+## El portal del cliente
+
+El portal es un espacio autocontenido acotado a un único cliente. Tiene su propio inicio de sesión (separado de tu cuenta de agencia) y muestra solo los agentes y conversaciones de ese cliente — la misma bandeja de entrada que usan tus operadores, pero limitada a un cliente. Desde ahí, el cliente puede cambiar una conversación a modo `human` para pausar la IA y responder él mismo.
+
+El portal está desactivado por defecto. Lo activas por cliente desde la configuración del cliente, y solo queda accesible una vez que se han definido un correo y una contraseña de acceso.
+
+## Configuración del portal
+
+En un cliente configuras estos campos:
+
+- **`portal_enabled`** — el interruptor que activa el portal. No se puede activar hasta que haya un `portal_email` y una contraseña.
+- **`portal_slug`** — el segmento de URL del portal (p. ej. `acme` → `/portal/acme`). Se genera a partir del nombre del cliente al crearlo, debe ser único y se normaliza a slug cuando lo cambias.
+- **`portal_title`** — el encabezado que se muestra en el inicio de sesión y la bandeja del portal. Si se deja vacío, usa `"<Nombre del cliente> Inbox"`.
+- **`portal_email`** — la dirección con la que inicia sesión el cliente.
+- **`portal_password`** — la contraseña del cliente (mínimo 8 caracteres). Se almacena con hash; la API solo informa si hay una configurada, nunca su valor.
+
+Activar el portal sin correo y contraseña se rechaza.
+
+## URL del portal
+
+Cada portal activado se sirve en:
+
+```
+/portal/<slug>
+```
+
+Por ejemplo, un cliente con slug `acme` en un stack en `https://app.example.com` accede a su portal en `https://app.example.com/portal/acme`. El inicio de sesión, la bandeja de entrada y las vistas de conversación del portal viven bajo esta ruta.
+
+## Dominio propio por cliente (opcional)
+
+En lugar de la ruta compartida `/portal/<slug>`, puedes apuntar el portal a un dominio que el cliente posea, como `support.acme.com`, con un certificado emitido automáticamente.
+
+### Añadir un dominio propio
+
+1. En la configuración del cliente, define el dominio propio (p. ej. `support.acme.com`). Al guardarlo se reinicia la verificación y se emite un token de desafío nuevo.
+2. Crea un registro DNS **TXT** en `_openlivery-challenge.<domain>` con el valor del token que aparece en la configuración.
+3. Haz clic en **Verificar**. OpenLivery resuelve el registro TXT; en cuanto coincide con el token, el dominio se marca como verificado.
+4. Apunta el dominio a tu servidor (un registro A/AAAA o CNAME para `support.acme.com`).
+5. Asegúrate de que la pasarela de TLS bajo demanda esté habilitada (ver más abajo) — el certificado se obtiene automáticamente en la primera petición.
+
+### Cómo funciona
+
+- El endpoint público y no autenticado `GET /api/public/portal-domain?domain=<host>` mapea un host a su portal. Devuelve `{ "portal_slug": ... }` solo cuando el dominio coincide con un cliente verificado y activado, y un código no-2xx en caso contrario.
+- El `proxy.ts` de Next.js resuelve el host entrante contra ese endpoint y reescribe un host verificado a `/portal/<slug>`, de modo que la URL del navegador permanece en el dominio propio del cliente. Alcanza la API en el lado del servidor mediante `BACKEND_INTERNAL_URL` — ver [Configuración](configuration.md).
+- `docker/Caddyfile.ondemand` restringe el TLS bajo demanda con el mismo endpoint como su hook `ask`, así que solo se emite un certificado para dominios de portal verificados y nunca para hosts arbitrarios apuntados al servidor.
+
+La pasarela bajo demanda es opcional. Consulta [Self-hosting](self-hosting.md) para montar el override y publicar los puertos 80 y 443.

--- a/docs/es/configuration.md
+++ b/docs/es/configuration.md
@@ -1,0 +1,58 @@
+# Configuración
+
+> Read in English: [configuration.md](../en/configuration.md)
+
+OpenLivery se configura mediante variables de entorno. En Docker, todas viven en un único archivo `.env.docker` en la raíz del repositorio; un script auxiliar lo genera con secretos aleatorios robustos para que nunca tengas que inventarlos.
+
+## El archivo .env.docker
+
+Ejecuta el generador una vez por clon:
+
+```bash
+./scripts/generate-docker-env.sh   # crea .env.docker y se niega a sobrescribir uno existente
+```
+
+Crea el archivo con permisos restrictivos (`umask 077`) y rellena los valores sensibles con `openssl rand`: una contraseña de Postgres, `SECRET_KEY`, `ENCRYPTION_KEY` y `WHATSAPP_BRIDGE_TOKEN`. Compose lee este archivo (`docker compose --env-file .env.docker`, que `make` hace por ti). El archivo está en gitignore: mantenlo fuera del control de versiones y guárdalo en un lugar seguro.
+
+Para una instalación local sin Docker, las mismas variables van en un `.env` en la raíz del repositorio o en `apps/api/.env`; consulta `.env.example`.
+
+## Variables principales
+
+| Variable | Propósito | Valor por defecto |
+| --- | --- | --- |
+| `DATABASE_URL` | Cadena de conexión de SQLAlchemy. En Docker se arma a partir de `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` apuntando al servicio `db` | Postgres local |
+| `SECRET_KEY` | Firma los tokens de sesión JWT. Rotarla cierra la sesión de todos | placeholder de desarrollo |
+| `ENCRYPTION_KEY` | Cifra las claves de API de IA y el estado de sesión de WhatsApp antes de guardarlos en la base de datos | placeholder de desarrollo |
+| `ACCESS_TOKEN_MINUTES` | Duración de la sesión | `10080` (7 días) |
+| `COOKIE_SECURE` | Enviar la cookie de sesión solo por HTTPS. Ponla en `true` en producción | `false` |
+| `COOKIE_SAMESITE` | Política SameSite de la cookie. Usa `none` cuando el frontend y la API están en sitios distintos (requiere `COOKIE_SECURE=true`) | `lax` |
+| `RATE_LIMIT_ENABLED` | Límite de peticiones por IP en endpoints públicos (auth, login del portal, widget) | `true` |
+| `FRONTEND_URL` | Origen permitido por CORS | `http://localhost:3000` |
+| `WHATSAPP_BRIDGE_TOKEN` | Secreto compartido que autentica las llamadas entre backend ↔ puente de WhatsApp. Usa el mismo valor en ambos | aleatorio |
+| `NEXT_PUBLIC_API_URL` | Origen público de la API incrustado en el frontend en tiempo de compilación. Déjalo vacío para usar el mismo origen a través del gateway | vacío |
+| `BACKEND_INTERNAL_URL` | Cómo alcanza el contenedor web a la API desde el servidor (usado por `proxy.ts` para dominios de portal personalizados) | `http://api:8000` |
+
+### La advertencia sobre ENCRYPTION_KEY
+
+`ENCRYPTION_KEY` **nunca** debe cambiar una vez que se han almacenado secretos. Deriva la clave que descifra cada clave de API de IA guardada y cada sesión de WhatsApp. Si la rotas o la pierdes, esos secretos quedan irrecuperables: tendrás que volver a introducir las claves de API y a vincular los números de WhatsApp. Trátala como permanente durante toda la vida de tu base de datos.
+
+## Puertos del host
+
+Compose enlaza cada servicio a un puerto del host, todos sobrescribibles. Pásalos en línea a `make up`:
+
+```bash
+API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up
+```
+
+| Variable | Qué controla | Valor por defecto |
+| --- | --- | --- |
+| `WEB_PORT` | El puerto del gateway: esta es la app | `3000` |
+| `API_PORT` | Backend, expuesto localmente para la documentación OpenAPI y herramientas | `8000` |
+| `DB_PORT` | PostgreSQL | `5432` |
+| `BIND_HOST` | Interfaz a la que enlazar: `127.0.0.1` solo local, `0.0.0.0` para exponer en un servidor | `127.0.0.1` |
+
+El puente de WhatsApp escucha en `3101` pero no se publica al host en Docker.
+
+## El gateway de origen único
+
+Un contenedor Caddy (`docker/Caddyfile`) sirve toda la pila en un único origen. Enruta `/api/*` al backend y todo lo demás al frontend, de modo que el navegador habla con un solo puerto y `NEXT_PUBLIC_API_URL` puede quedar vacío. La pila sirve solo HTTP plano: coloca tu propio reverse proxy delante del gateway para TLS en producción. Consulta [Autoalojamiento](self-hosting.md) para un despliegue público.

--- a/docs/es/contributing.md
+++ b/docs/es/contributing.md
@@ -1,0 +1,96 @@
+# Contribuir
+
+> Read in English: [contributing.md](../en/contributing.md)
+
+Docker es la forma más rápida de ejecutar OpenLivery, pero para el desarrollo diario normalmente querrás cada servicio corriendo en tu máquina con recarga en caliente. Esta guía cubre cómo ejecutar el backend, el frontend y el puente de WhatsApp localmente, las suites de pruebas, las migraciones y las convenciones del proyecto.
+
+## Requisitos previos
+
+Clona el repositorio y activa el guard de pre-commit una vez por clon:
+
+```bash
+git clone https://github.com/sarrazola/openlivery.git
+cd openlivery
+git config core.hooksPath .githooks
+```
+
+El guard (`.githooks/pre-commit`) impide commitear archivos locales y cualquier contenido preparado marcado como interno. Necesitas Python 3.12, Node.js y una instancia de PostgreSQL en ejecución a la que el backend pueda conectarse.
+
+## Backend (apps/api)
+
+Copia `.env.example` a `.env` y apunta `DATABASE_URL` a tu PostgreSQL. Instala las dependencias, aplica las migraciones y arranca el servidor con recarga:
+
+```bash
+cd apps/api
+pip install -r requirements.txt
+alembic upgrade head            # las migraciones deben ejecutarse antes de arrancar
+uvicorn app.main:app --reload --port 8000
+```
+
+La documentación OpenAPI se sirve en [http://localhost:8000/docs](http://localhost:8000/docs).
+
+## Frontend (apps/web)
+
+```bash
+cd apps/web
+npm install
+npm run dev                     # http://localhost:3000
+```
+
+Usa `npm run lint` antes de commitear y `npm run build` para verificar un build de producción. Ten en cuenta que esto es Next.js 16 (App Router) — revisa la documentación incluida en `node_modules/next/dist/docs/` antes de escribir código Next.js no trivial, ya que varias APIs difieren de versiones anteriores.
+
+## Puente de WhatsApp (apps/whatsapp)
+
+```bash
+cd apps/whatsapp
+npm install
+npm run dev                     # tsx watch, escucha en :3101
+```
+
+Ejecuta `npm test` para la suite de pruebas y `npm run build` para hacer typecheck con `tsc`.
+
+## Pruebas
+
+Las pruebas del backend necesitan una base de datos **separada** — nunca las apuntes a tu base de datos de desarrollo. Por defecto usan `openlivery_test` en localhost y crean/eliminan todas las tablas por prueba. Cambia el destino con `TEST_DATABASE_URL`:
+
+```bash
+cd apps/api
+pytest -q
+TEST_DATABASE_URL=postgresql+psycopg://user:pass@localhost:5432/openlivery_test pytest -q
+```
+
+Ejecuta una sola prueba por su identificador:
+
+```bash
+pytest tests/test_flows.py::test_register_login_logout_and_me -v
+```
+
+## Migraciones de base de datos
+
+Cualquier cambio de esquema requiere una nueva migración de Alembic — Docker ejecuta `alembic upgrade head` al arrancar el backend, así que un cambio sin migración romperá el stack en contenedores. Genera una tras editar los modelos, revisa el archivo generado y luego aplícala.
+
+## Convenciones
+
+Todo el código, los identificadores, los comentarios, los mensajes de commit y la documentación se escriben en **inglés**, siempre. Lo único que se localiza es la interfaz de usuario final, a través del sistema tipado de i18n en `apps/web/lib/i18n` (inglés por defecto, español por ahora). Nunca introduzcas texto que no sea inglés en el código o la documentación — coloca el texto visible para el usuario detrás de claves de i18n.
+
+## Referencia de comandos
+
+| Servicio | Comando | Qué hace |
+| --- | --- | --- |
+| Backend | `pip install -r requirements.txt` | Instala las dependencias de Python |
+| Backend | `alembic upgrade head` | Aplica las migraciones pendientes |
+| Backend | `uvicorn app.main:app --reload --port 8000` | Ejecuta la API con recarga en caliente |
+| Backend | `pytest -q` | Ejecuta la suite de pruebas |
+| Frontend | `npm install` | Instala las dependencias |
+| Frontend | `npm run dev` | Ejecuta el servidor de desarrollo en :3000 |
+| Frontend | `npm run lint` | Analiza con ESLint |
+| Frontend | `npm run build` | Build de producción |
+| WhatsApp | `npm run dev` | Ejecuta el puente en :3101 |
+| WhatsApp | `npm test` | Ejecuta la suite de pruebas |
+| WhatsApp | `npm run build` | Typecheck con tsc |
+
+## Próximos pasos
+
+- [Arquitectura](architecture.md) — cómo encajan los servicios entre sí.
+- [Configuración](configuration.md) — variables de entorno, secretos y puertos.
+- [Auto-alojamiento](self-hosting.md) — despliega en un servidor público con TLS y copias de seguridad.

--- a/docs/es/custom-tools.md
+++ b/docs/es/custom-tools.md
@@ -1,0 +1,49 @@
+# Herramientas personalizadas
+
+> Read in English: [custom-tools.md](../en/custom-tools.md)
+
+Las herramientas personalizadas permiten que un agente actúe, no solo responda. Desde la pestaña **Herramientas** del editor del agente puedes conectar dos tipos de herramientas, y el agente decide cuándo llamarlas durante una conversación: **herramientas HTTP** (un endpoint propio o cualquier API REST) y **servidores MCP** (servicios externos que hablan el Model Context Protocol). Las herramientas funcionan en todos los canales: el playground, el widget web y WhatsApp.
+
+## Herramientas HTTP
+
+Una herramienta HTTP describe un endpoint que el agente puede llamar:
+
+- **Nombre** — en `snake_case`, se usa como el nombre de función que ve el modelo (por ejemplo `check_order`). No se permiten guiones bajos consecutivos.
+- **URL y método** — la URL puede contener placeholders `{param}` (por ejemplo `https://api.example.com/orders/{order_id}`); cada placeholder se convierte automáticamente en una entrada obligatoria que el modelo debe proporcionar. Métodos: GET, POST, PUT, PATCH o DELETE.
+- **Instrucciones para el prompt** — dile al agente cuándo y cómo usar la herramienta. Este texto se añade a la descripción que ve el modelo, así que sé específico con las condiciones y los datos requeridos.
+- **Parámetros de body y query** — cada parámetro tiene nombre, tipo (`string`, `number`, `integer`, `boolean`), descripción y si es obligatorio. Los parámetros de body solo se permiten en POST, PUT y PATCH.
+- **Opciones avanzadas** — headers de autenticación (por ejemplo `Authorization: Bearer …`) y un timeout entre 1 y 120 segundos (30 por defecto). Los valores de los headers se **guardan cifrados** y la API no los devuelve ni la UI los vuelve a mostrar; solo puedes reemplazarlos.
+
+Cuando el modelo llama la herramienta, OpenLivery sustituye los placeholders de la ruta, envía los parámetros de query y el body JSON declarados, y devuelve la respuesta al modelo como `HTTP <status>: <body>`. Las respuestas se limitan a 100 KB.
+
+## Servidores MCP
+
+Un servidor MCP conecta al agente con todas las herramientas que ese servidor expone:
+
+- **Nombre del servidor** — en `snake_case`, hasta 24 caracteres. Las herramientas del servidor se exponen al modelo como `<servidor>__<herramienta>` (por ejemplo `weather__get_forecast`), lo que evita colisiones de nombres entre servidores.
+- **URL y transporte** — Streamable HTTP o SSE.
+- **Headers de autenticación** — opcionales, cifrados igual que en las herramientas HTTP.
+
+Antes de guardar un servidor debes ejecutar **Probar conexión**, que conecta, realiza el handshake MCP y lista las herramientas del servidor. La lista descubierta se guarda en caché y se reutiliza durante el chat, así las conversaciones nunca esperan por el descubrimiento; editar la URL, el transporte o los headers repite la comprobación. Crear o actualizar un servidor cuya conexión falla se rechaza.
+
+## Cómo funciona el tool calling
+
+Cuando un agente con herramientas activas recibe un mensaje, OpenLivery envía las definiciones de las herramientas al modelo junto con la conversación. Si el modelo decide llamar una herramienta, OpenLivery la ejecuta (la petición HTTP, o una llamada proxied al servidor MCP), le devuelve el resultado y deja que el modelo continúe — hasta **5 rondas** por respuesta, tras las cuales el modelo debe responder con texto. Funciona con ambos proveedores: OpenAI (Responses API) y Anthropic (Messages API). El uso de tokens de todas las rondas se suma en el registro de uso de la respuesta.
+
+Cada respuesta del asistente guarda qué herramientas se ejecutaron, con sus argumentos y una vista previa de cada resultado. En el playground verás un chip bajo la respuesta con las herramientas usadas; las llamadas fallidas se resaltan y muestran el detalle del error, para diagnosticar una herramienta rota sin leer logs.
+
+Si una llamada falla, el agente tiene instrucciones de decirle al usuario que la información o acción no está disponible en este momento — no responderá en silencio con su propio conocimiento.
+
+## Seguridad
+
+- **Las redes privadas están bloqueadas por defecto.** Las URLs de herramientas HTTP que resuelven a direcciones privadas, de loopback o reservadas (incluidos los endpoints de metadata de la nube) se rechazan en el momento de la petición. Los despliegues autoalojados que necesiten herramientas contra servicios internos pueden desactivarlo con `TOOLS_ALLOW_PRIVATE_URLS=true`.
+- **Las redirecciones nunca se siguen.** Una respuesta 3xx cuenta como llamada fallida: el dato no se obtuvo, y seguir redirecciones a ciegas evadiría la comprobación de direcciones.
+- **Los secretos permanecen cifrados.** Los headers de autenticación se cifran con la misma `ENCRYPTION_KEY` de las claves de proveedores (ver [Configuración](configuration.md)) y nunca vuelven al navegador.
+
+## Solución de problemas
+
+- **"Could not connect to the MCP server"** — el mensaje incluye la causa: credenciales rechazadas (revisa el formato del header `Authorization`, normalmente `Bearer <token>`), host inalcanzable, timeout, o un endpoint que no responde como servidor MCP (revisa la URL y el transporte).
+- **El agente nunca llama la herramienta** — haz concretas las instrucciones del prompt ("Úsala cuando el cliente pregunte por el estado de un pedido"), verifica que el toggle de la herramienta esté activo, y menciona el dato en tu mensaje de prueba ("¿cuál es el estado del pedido 42?").
+- **Una herramienta que funcionaba empieza a fallar** — la API destino puede haberse movido detrás de una redirección o cambiado la autenticación. El detalle del error en el playground muestra el status exacto que recibió la herramienta.
+
+Consulta [Agentes](agents.md) para el resto del editor del agente y [Proveedores de IA](ai-providers.md) para conectar un modelo con soporte de tool calling.

--- a/docs/es/dashboard.md
+++ b/docs/es/dashboard.md
@@ -1,0 +1,38 @@
+# Panel
+
+> Read in English: [dashboard.md](../en/dashboard.md)
+
+El panel es la pantalla de inicio de tu agencia: lo primero que ves al iniciar sesión. Resume la actividad de cada cliente, agente y canal en un solo lugar, y se adapta al rango de fechas que elijas.
+
+## Rango de fechas
+
+Un selector en la esquina superior derecha controla la ventana que usan las gráficas y los contadores. Las opciones son **7, 14, 30 y 90 días**, con 14 por defecto. Cambiarlo vuelve a cargar las métricas para la nueva ventana.
+
+## Próximos pasos
+
+Hasta que tu espacio de trabajo esté configurado, una lista de bienvenida te guía por las primeras tareas: crear un cliente, crear un agente y conectar un canal. Los dos primeros pasos se marcan solos en cuanto tienes al menos un cliente y un agente.
+
+## Métricas principales
+
+En la parte superior hay cuatro tarjetas, cada una con un total más una línea secundaria:
+
+- **Clientes** — total de clientes, con cuántos están activos.
+- **Agentes** — total de agentes, con cuántos están activos.
+- **Conversaciones** — total de conversaciones de todos los canales.
+- **Canales** — total de canales de WhatsApp, con cuántos están conectados.
+
+## Actividad
+
+El panel de actividad grafica las **nuevas conversaciones por día** durante la ventana seleccionada en un gráfico de barras (relleno con ceros, para que aparezca cada día aunque no haya tráfico). Junto a él, dos contadores cubren la misma ventana: total de **mensajes** y conversaciones **atendidas por una persona** (las que se pasaron a modo humano para que un operador responda desde la bandeja). Consulta [Bandeja de entrada](inbox.md).
+
+## Agentes destacados
+
+Una lista ordenada muestra tus agentes más activos por número de conversaciones en la ventana, hasta cinco. Cada fila enlaza directamente a ese agente. Consulta [Agentes](agents.md).
+
+## Uso de tokens por modelo
+
+Este panel desglosa el consumo por modelo durante la ventana, hasta seis modelos, ordenados por total de tokens. Cada fila muestra el nombre del modelo y una barra con su total, y el encabezado del panel muestra los tokens agregados de **entrada** (↓) y **salida** (↑) de toda la ventana. Refleja el uso real registrado por cada petición, así que permanece vacío hasta que tus agentes empiecen a responder.
+
+## Agentes recientes
+
+Al final se listan los cinco agentes creados más recientemente con su cliente y estado, además de un enlace a la lista completa de [Agentes](agents.md).

--- a/docs/es/getting-started.md
+++ b/docs/es/getting-started.md
@@ -1,0 +1,60 @@
+# Primeros pasos
+
+> Read in English: [getting-started.md](../en/getting-started.md)
+
+OpenLivery se ejecuta como tres servicios más PostgreSQL, orquestados por Docker Compose. La forma más rápida de probarlo es clonar el repositorio, generar los secretos y levantar el stack con un solo comando.
+
+## Requisitos
+
+Necesitas [Docker](https://docs.docker.com/get-docker/) — Docker Desktop, o Docker Engine con el plugin de Compose. No se instala nada más en el host; cada servicio (frontend, backend, puente de WhatsApp y base de datos) se ejecuta en un contenedor.
+
+## Instalar y ejecutar
+
+```bash
+git clone https://github.com/sarrazola/openlivery.git
+cd openlivery
+./scripts/generate-docker-env.sh   # crea .env.docker con secretos aleatorios (gitignored)
+make up                            # construye imágenes, inicia servicios y migra
+```
+
+`make up` envuelve a Docker Compose: construye las imágenes, inicia los cuatro servicios y aplica las migraciones de la base de datos antes de que la API acepte tráfico.
+
+## Abre la aplicación
+
+Cuando el stack esté saludable:
+
+- **App** — [http://localhost:3000](http://localhost:3000)
+- **Docs de la API (OpenAPI)** — [http://localhost:8000/docs](http://localhost:8000/docs)
+
+Si esos puertos ya están en uso, sobrescríbelos en línea:
+
+```bash
+API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up
+```
+
+¿Prefieres no construir en local? `make pull` ejecuta las imágenes prediseñadas publicadas en GHCR en lugar de construir desde el código.
+
+## Primeros pasos
+
+1. **Crea tu agencia** en la primera pantalla — es el espacio de trabajo principal que posee todo lo demás.
+2. Abre **Ajustes** y añade una clave de OpenAI y/o Anthropic. La clave se verifica al guardarla. Consulta [Proveedores de IA](ai-providers.md).
+3. Crea un **cliente** y luego un **agente** para ese cliente: elige proveedor y modelo, y escribe las instrucciones del agente. Consulta [Agentes](agents.md).
+4. Añade conocimiento (contexto, pares de preguntas y respuestas, PDFs) y opcionalmente activa la comprensión de imágenes o audio. Consulta [Base de conocimiento](knowledge-base.md).
+5. Abre el **Playground** para chatear con el agente, y luego conecta un número de [WhatsApp](whatsapp.md) o integra el [widget web](web-widget.md).
+
+## Comandos útiles
+
+| Comando | Qué hace |
+| --- | --- |
+| `make up` | Construye, inicia y migra todo el stack |
+| `make down` | Detiene y elimina los contenedores |
+| `make logs` | Sigue los logs de todos los servicios |
+| `make migrate` | Aplica las migraciones pendientes |
+| `make test` | Ejecuta la suite de pruebas del backend |
+| `make help` | Lista todos los objetivos disponibles |
+
+## Siguientes pasos
+
+- [Configuración](configuration.md) — variables de entorno, secretos y puertos.
+- [Arquitectura](architecture.md) — cómo encajan los servicios.
+- [Autoalojamiento](self-hosting.md) — despliega en un servidor público con TLS y copias de seguridad.

--- a/docs/es/inbox.md
+++ b/docs/es/inbox.md
@@ -1,0 +1,36 @@
+# Bandeja de entrada
+
+> Read in English: [inbox.md](../en/inbox.md)
+
+La bandeja de entrada (Inbox) es un único lugar para observar todas las conversaciones que mantienen tus agentes, buscar entre ellas e intervenir como humano cuando la IA necesita ayuda. Reúne las conversaciones de todos los canales — el playground, [WhatsApp](whatsapp.md) y el [widget web](web-widget.md) — en una sola lista.
+
+## Lista unificada
+
+Cada conversación muestra el nombre del contacto (o el título), una vista previa del último mensaje, el agente que la atiende, el canal por el que llegó y una etiqueta que indica si está en modo **AI** o **human**. La lista está acotada a tu agencia, por lo que los operadores solo ven las conversaciones de su propio inquilino.
+
+Dos filtros en la parte superior acotan la vista: por **agente** y por **canal** (playground, WhatsApp o widget). Estos se combinan con las pestañas y la búsqueda de abajo.
+
+## Búsqueda y pestañas
+
+El cuadro de búsqueda funciona **del lado del servidor**: coincide con el título de la conversación, el nombre del contacto y el contenido del último mensaje. La entrada tiene un retardo (debounce), así que los resultados se actualizan poco después de dejar de escribir.
+
+Cuatro pestañas filtran la lista:
+
+- **All** — todas las conversaciones.
+- **Unread** — conversaciones cuyo último mensaje es del visitante y no se ha leído desde entonces.
+- **Human** — conversaciones actualmente en modo humano.
+- **AI** — conversaciones que atiende el agente en ese momento.
+
+## Seguimiento de no leídos y paginación
+
+El estado de no leído se deriva de una marca de tiempo `operator_read_at`: una conversación cuenta como no leída cuando su último mensaje proviene del visitante y llegó después de la última vez que la abriste. Abrir una conversación la marca como leída. La primera página se refresca automáticamente cada pocos segundos para que los mensajes nuevos aparezcan sin recargar a mano. La lista se carga en páginas de 30 y trae más a medida que te desplazas hacia el final.
+
+## Toma de control humana
+
+Cada conversación lleva un campo `mode`. En modo **AI** el agente responde automáticamente. Usa **Tomar el control** para cambiar la conversación a modo **human**: esto pausa la IA para que un operador responda en su lugar. Mientras una conversación está en modo humano, la IA no genera respuestas — los intentos de hacerlo se rechazan hasta que la devuelvas. Cuando termines, **Devolver a la IA** vuelve a cambiar el modo y el agente reanuda.
+
+Es el mismo concepto de `mode` usado en las conversaciones de [WhatsApp](whatsapp.md), por lo que tomar el control funciona de forma consistente sin importar el canal.
+
+## Quién puede tomar el control
+
+Tanto los operadores de la agencia (desde esta bandeja de entrada) como los usuarios del cliente pueden tomar el control de las conversaciones. Los usuarios del cliente lo hacen desde el [portal del cliente](client-portal.md), que expone las mismas acciones de tomar el control y responder como humano, acotadas a su cliente.

--- a/docs/es/knowledge-base.md
+++ b/docs/es/knowledge-base.md
@@ -1,0 +1,42 @@
+# Base de conocimiento
+
+> Read in English: [knowledge-base.md](../en/knowledge-base.md)
+
+La base de conocimiento es la forma de dar a un agente los datos del negocio que necesita para responder con precisión. Añades conocimiento desde tres tipos de fuentes y OpenLivery ensambla las partes relevantes en el prompt de sistema del agente en cada mensaje.
+
+## Fuentes de conocimiento
+
+- **Contexto general** — texto libre sobre el cliente (compartido entre los agentes de ese cliente) y un contexto manual por agente. Úsalo para todo lo que puedas describir en prosa: horarios, tono, posicionamiento, políticas.
+- **Pares de preguntas y respuestas** — entradas estructuradas de pregunta/respuesta. Son ideales para preguntas frecuentes donde quieres una respuesta específica y fiable.
+- **PDFs subidos** — adjunta documentos (catálogos, manuales, listas de precios) y el agente lee de su texto. Los PDFs tienen un límite de 20 MB y solo se aceptan archivos PDF.
+
+Consulta [Agentes](agents.md) para ver dónde se gestionan en el editor del agente.
+
+## Cómo se procesan los PDFs
+
+Cuando subes un PDF, su texto se extrae de inmediato con `pypdf` y se guarda en el documento. Si no se puede extraer texto (por ejemplo, un PDF escaneado que solo contiene imágenes), el documento se marca como `error` y no se utiliza. El texto extraído se divide luego en fragmentos del tamaño de un párrafo. Cuando hay disponible una conexión compatible con OpenAI que soporta embeddings, cada fragmento se convierte en un vector que se guarda junto a él; el embedding es de mejor esfuerzo, así que si no está disponible el agente sigue funcionando mediante búsqueda por palabras clave.
+
+## Cómo funciona la recuperación
+
+En cada mensaje entrante, OpenLivery decide cuánto texto de documentos incluir:
+
+- **Las bases de conocimiento pequeñas se envían completas.** Cuando el texto extraído combinado de todos los documentos procesados es igual o menor a **45.000 caracteres**, cada documento se incluye textualmente, sin paso de búsqueda.
+- **Las bases de conocimiento más grandes se recuperan.** Por encima de ese umbral, OpenLivery ejecuta una búsqueda semántica: convierte la consulta del usuario en un vector y ordena los fragmentos almacenados por similitud de coseno, llenando el contexto hasta un presupuesto de búsqueda. Si los embeddings no están disponibles, recurre al ranking por palabras clave sobre los fragmentos.
+
+Los embeddings se guardan como un simple **arreglo JSON de números** y la similitud se calcula en Python, por lo que **no se requiere ninguna extensión de base de datos** — la base de conocimiento es portable en cualquier PostgreSQL. Consulta [Proveedores de IA](ai-providers.md) para configurar la conexión usada para los embeddings.
+
+## Cómo se ensambla el prompt de sistema
+
+Todo se compone en un único mensaje de sistema, en este orden:
+
+1. La línea de identidad del agente (nombre y cliente).
+2. La fecha y hora actual, en la zona horaria configurada del agente.
+3. Instrucciones principales.
+4. Personalidad y tono.
+5. El brief del negocio, si está completado.
+6. El contexto general del cliente.
+7. El contexto manual del agente.
+8. Los pares de preguntas y respuestas.
+9. El texto de conocimiento de los PDFs recuperado (o completo).
+
+El historial reciente de la conversación se añade después de este mensaje de sistema. Cualquier sección vacía se omite, así que el prompt solo lleva lo que realmente has proporcionado.

--- a/docs/es/push-notifications.md
+++ b/docs/es/push-notifications.md
@@ -1,0 +1,120 @@
+# Notificaciones push
+
+> Read in English: [push-notifications.md](../en/push-notifications.md)
+
+OpenLivery trae la *fontanería* de notificaciones y ningún *proveedor*. En una
+instalación por defecto no hay cuenta que crear, ningún tercero involucrado y
+nada que pagar: `PUSH_PROVIDER` vale `none` y el servidor no envía nada.
+
+Esta página explica qué hace esa fontanería, qué opciones tienes para
+encenderla, y la restricción que suele tomar a la gente por sorpresa.
+
+## La restricción que conviene leer primero
+
+En iOS y Android las credenciales de push están atadas al **binario de la app**,
+no al servidor. Apple emite una clave APNs para la cuenta de desarrollador que
+publica la app; Google emite un sender de FCM para el nombre del paquete. Un
+servidor solo puede notificar a una app compilada contra el proveedor por el que
+ese servidor envía.
+
+La consecuencia práctica:
+
+- **Corres tu propio OpenLivery y usas la app oficial de la tienda.** Esa app
+  lee y responde todo en tu servidor sin problema, pero no puede recibir push
+  desde él: la compilación de la tienda solo acepta notificaciones de las
+  credenciales con las que se firmó, que son de quien la publicó. Es el modelo
+  de Apple y de Google, no una limitación que añadimos nosotros.
+- **Compilas la app tú mismo** con tu propio identificador de paquete y tus
+  credenciales de push, que es justo lo que ya soporta la configuración de marca
+  blanca; mira [`apps/mobile/WHITELABEL.md`](../../apps/mobile/WHITELABEL.md).
+  Ahí el push es enteramente tuyo: eliges el proveedor, tienes las claves, y le
+  pagas a quien elegiste (o a nadie).
+
+Así que el push no es algo que le falte a un servidor autoalojado. Es algo que
+viene con compilar tu propia app, y esta costura es lo que conecta las dos.
+
+## Cómo funciona
+
+Tres piezas, todas en el core:
+
+1. **Un registro de dispositivos.** Cuando alguien inicia sesión en un teléfono,
+   la app se registra con `POST /api/mobile/devices` y envía el token que le dio
+   su proveedor. `GET /api/mobile/session` responde con `push.provider`, así que
+   una app apuntada a un servidor con el push apagado no inicializa ningún SDK
+   de push: nadie se suscribe, así que a nadie se le factura.
+2. **Un punto de despacho.** Cuando llega un mensaje a una conversación que un
+   operador tomó, el servidor notifica a los dispositivos registrados de ese
+   cliente. Mientras responde el asistente no se envía nada: un teléfono que
+   vibra con cada mensaje de cada cliente es un teléfono al que le apagan las
+   notificaciones.
+3. **Un proveedor.** Una sola función que recibe una `Notification` y la
+   entrega.
+
+## Encenderlo
+
+### `none` (por defecto)
+
+No envía nada. Sin configuración, sin dependencias, sin coste.
+
+### `webhook`
+
+Cada notificación se envía por POST como JSON a una URL que tú controlas, y
+desde ahí la enrutas: ntfy, Gotify, Home Assistant, un incoming hook de Slack,
+una cola, o un script de cinco líneas que llame al servicio que ya pagas.
+
+```bash
+PUSH_PROVIDER=webhook
+PUSH_WEBHOOK_URL=https://example.com/openlivery-push
+PUSH_WEBHOOK_SECRET=a-shared-secret   # optional; sent as a Bearer token
+```
+
+El cuerpo es estable:
+
+```json
+{
+  "title": "Marta Ruiz",
+  "body": "Hi, are you open on Saturday?",
+  "data": { "conversation_id": "…", "client_id": "…" },
+  "devices": [{ "token": "…", "platform": "ios" }]
+}
+```
+
+### Tu propio proveedor
+
+Un proveedor es una única función asíncrona. Regístrala al arrancar, desde un
+módulo envoltorio que importe la app, y así nunca tienes que editar este
+repositorio:
+
+```python
+from app.services.notifications import Notification, register_provider
+
+async def send_via_my_service(notification: Notification) -> int:
+    ...  # deliver however you like
+    return len(notification.devices)
+
+register_provider("my-service", send_via_my_service)
+```
+
+Después pon `PUSH_PROVIDER=my-service`. Registrar un nombre que ya existe lo
+reemplaza, así que también puedes sustituir uno de los incluidos sin hacer un
+fork.
+
+Las filas de dispositivos recuerdan qué proveedor emitió su token, y los tokens
+de un proveedor que ya no usas se saltan en vez de enviarse a un sitio donde no
+pueden llegar. Después de cambiar de proveedor, las apps se vuelven a registrar
+en su siguiente arranque.
+
+## A quién se notifica
+
+Las notificaciones van a todos los dispositivos registrados del **cliente** al
+que pertenece la conversación. Si una barbería tiene tres personas atendiendo,
+suenan los tres teléfonos y se la queda quien llegue primero. Los dispositivos
+también están ligados al usuario del portal que los registró, así que quitar a
+alguien de `/clients/{id}/portal-users` corta su teléfono de inmediato.
+
+## Comportamiento ante fallos
+
+La entrega es de mejor esfuerzo, a propósito. El mensaje ya está guardado y va a
+estar ahí cuando la app se abra, así que un proveedor caído, mal configurado o
+lento nunca hace fallar la petición que lo originó. Los fallos se registran en
+el log y se tragan.

--- a/docs/es/self-hosting.md
+++ b/docs/es/self-hosting.md
@@ -1,0 +1,111 @@
+# Autoalojamiento
+
+> Read in English: [self-hosting.md](../en/self-hosting.md)
+
+Ejecutar OpenLivery en un servidor usa el mismo stack de Docker Compose que en local, más tu propio proxy inverso por delante para el TLS. Una instancia equivale a una agencia, y todos los datos viven en volúmenes que respaldas y conservas entre actualizaciones.
+
+## Desplegar en un servidor público
+
+El stack sirve HTTP plano a través de un gateway Caddy de un solo origen: `/api/*` va al backend y todo lo demás al frontend. El TLS lo proporciona el operador — no hay TLS incluido ni `make deploy`. Coloca tu propio proxy inverso (Caddy, nginx, Traefik o un balanceador de carga en la nube) delante del puerto del gateway para terminar HTTPS con tu dominio.
+
+1. Clona el repositorio y levanta el stack como en [Primeros pasos](getting-started.md):
+
+   ```bash
+   git clone https://github.com/sarrazola/openlivery.git
+   cd openlivery
+   ./scripts/generate-docker-env.sh
+   make up
+   ```
+
+2. El gateway escucha en `${WEB_PORT}` (por defecto `3000`), enlazado a `127.0.0.1`. Apunta tu proxy inverso a `127.0.0.1:3000`. Como la app y la API comparten un mismo origen, redirige el **dominio completo** a ese único puerto.
+3. Configura `COOKIE_SECURE=true` en `.env.docker` y reinicia, para que la cookie de sesión solo se envíe por TLS.
+
+Mantén la base de datos, la API y el puente de WhatsApp privados dejando `BIND_HOST=127.0.0.1` (el valor por defecto); solo tu proxy inverso debe estar expuesto a internet. Para la lista completa de variables consulta [Configuración](configuration.md).
+
+Un ejemplo mínimo con Caddy en el host:
+
+```caddyfile
+agency.example.com {
+	reverse_proxy 127.0.0.1:3000
+}
+```
+
+## Datos persistentes
+
+Todo el estado vive en volúmenes de Docker con nombre, por lo que `make down` y las actualizaciones lo conservan:
+
+| Volumen | Contenido |
+| --- | --- |
+| `postgres_data` | La base de datos PostgreSQL — agencias, agentes, conversaciones, claves de proveedor cifradas y el estado cifrado de la sesión de WhatsApp. |
+| `backend_storage` | Archivos subidos (por ejemplo, los PDF de la base de conocimiento). |
+
+La `ENCRYPTION_KEY` descifra las claves de API de los proveedores y las sesiones de WhatsApp. **Nunca la cambies** una vez almacenados los secretos, o quedarán irrecuperables — trátala como parte de tu copia de seguridad.
+
+## Copias de seguridad y restauración
+
+Exporta PostgreSQL sin detener la app:
+
+```bash
+mkdir -p backups
+docker compose --env-file .env.docker exec -T db \
+  sh -c 'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc' > backups/openlivery.dump
+```
+
+Guarda también `.env.docker` en un gestor de secretos: un volcado con claves de API o una sesión de WhatsApp necesita la misma `ENCRYPTION_KEY` para descifrarse. Restaura (reemplaza los datos de la base de datos de destino — haz una copia antes):
+
+```bash
+docker compose --env-file .env.docker stop api whatsapp
+docker compose --env-file .env.docker exec -T db \
+  sh -c 'pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists --no-owner' < backups/openlivery.dump
+docker compose --env-file .env.docker start api whatsapp
+```
+
+## Actualizaciones
+
+Descarga la nueva versión y reconstruye — los volúmenes de datos quedan intactos:
+
+```bash
+git pull
+make up        # reconstruye y reinicia; tu proxy inverso sigue por delante
+```
+
+El backend ejecuta `alembic upgrade head` al arrancar, por lo que los cambios de esquema se aplican sin borrar `postgres_data`. ¿Ejecutas desde imágenes prediseñadas? Usa `make pull` (fija una versión con `OPENLIVERY_VERSION=v1.2.3 make pull`). Haz una copia de seguridad antes.
+
+## Dominios personalizados para portales de cliente
+
+Por defecto el portal de un cliente vive en `tu-dominio/portal/<slug>`. También puedes servirlo bajo el dominio propio del cliente con TLS bajo demanda, un override opcional que monta `docker/Caddyfile.ondemand` y publica los puertos 80/443 en el gateway. El recorrido completo — el `docker-compose.override.yml`, los registros DNS y la verificación — está en [Portal de cliente](client-portal.md).
+
+## Ejecutar sin Docker
+
+Para una configuración local sin contenedores ejecutas cada servicio a mano. Requisitos: Python 3.12+, Node.js 20+, PostgreSQL 14+.
+
+```bash
+# 1) databases
+psql -d postgres -c "CREATE ROLE openlivery LOGIN PASSWORD 'openlivery';"
+createdb -O openlivery openlivery
+createdb -O openlivery openlivery_test
+
+# 2) env
+cp .env.example .env          # then set SECRET_KEY and ENCRYPTION_KEY
+
+# 3) backend
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r apps/api/requirements.txt
+cd apps/api && alembic upgrade head && uvicorn app.main:app --reload --port 8000
+
+# 4) frontend (new terminal)
+cd apps/web && npm install && npm run dev
+
+# 5) WhatsApp bridge (new terminal)
+cd apps/whatsapp && npm install && npm run start
+```
+
+El puente escucha solo en `127.0.0.1:3101` y debe seguir en ejecución junto al backend. Consulta `.env.example` para la lista completa de variables (`DATABASE_URL`, `BACKEND_URL`, `WHATSAPP_BRIDGE_URL`, `WHATSAPP_BRIDGE_PORT`, …).
+
+## Solución de problemas
+
+- **Puertos ya en uso.** Sobrescríbelos en línea: `API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up`.
+- **Un servicio está unhealthy.** Revisa sus logs con `make logs SERVICE=api` (o `web`, `whatsapp`, `db`) y `make ps` para ver el estado.
+- **La sesión no persiste / bucle de inicio de sesión tras HTTPS.** Asegúrate de que `COOKIE_SECURE=true` está configurado y de que accedes a la app por TLS.
+- **Las claves de proveedor o la sesión de WhatsApp dejaron de descifrarse.** La `ENCRYPTION_KEY` cambió — restaura el valor original desde tu copia de seguridad.
+- **WhatsApp pide un nuevo QR tras reiniciar.** Es normal solo si WhatsApp terminó la sesión, se desvinculó el dispositivo o cambió la `ENCRYPTION_KEY`; de lo contrario el puente recarga las sesiones habilitadas desde PostgreSQL automáticamente.

--- a/docs/es/self-hosting.md
+++ b/docs/es/self-hosting.md
@@ -1,28 +1,165 @@
-# Autoalojamiento
+# Autoalojar OpenLivery
 
 > Read in English: [self-hosting.md](../en/self-hosting.md)
 
-Ejecutar OpenLivery en un servidor usa el mismo stack de Docker Compose que en local, más tu propio proxy inverso por delante para el TLS. Una instancia equivale a una agencia, y todos los datos viven en volúmenes que respaldas y conservas entre actualizaciones.
+Levanta y opera tu propia instancia de OpenLivery. Para una vista general de las
+funcionalidades, mira el [README](../../README.md).
 
-## Desplegar en un servidor público
+OpenLivery se orquesta con Docker Compose, y un `Makefile` envuelve los comandos
+habituales. Un **gateway** ligero (Caddy) es el único punto de entrada público:
+sirve la aplicación y enruta `/api/*` al backend, así que el frontend y la API
+comparten un mismo origen.
 
-El stack sirve HTTP plano a través de un gateway Caddy de un solo origen: `/api/*` va al backend y todo lo demás al frontend. El TLS lo proporciona el operador — no hay TLS incluido ni `make deploy`. Coloca tu propio proxy inverso (Caddy, nginx, Traefik o un balanceador de carga en la nube) delante del puerto del gateway para terminar HTTPS con tu dominio.
+| Servicio | Imagen | Rol |
+| --- | --- | --- |
+| `proxy` | Caddy | Gateway HTTP, el origen único de la app (enruta `/api/*` → backend). |
+| `web` | Next.js | Panel de la agencia, portal del cliente, playground y widget (interno). |
+| `api` | FastAPI | API REST, modelos, servicios de IA, conocimiento y proveedores (interno). |
+| `db` | PostgreSQL | Todos los datos, con los secretos cifrados en reposo (interno). |
+| `whatsapp` | Node.js + Baileys | Puente con WhatsApp Web (interno). |
 
-1. Clona el repositorio y levanta el stack como en [Primeros pasos](getting-started.md):
+Solo el gateway está pensado para ser público. Para HTTPS, pon tu propio proxy
+inverso delante (mira [Pasar a producción](#pasar-a-producción-https)). Una
+instancia = **una agencia** (el primer usuario registrado es su administrador).
 
-   ```bash
-   git clone https://github.com/sarrazola/openlivery.git
-   cd openlivery
-   ./scripts/generate-docker-env.sh
-   make up
-   ```
+> **¿Por qué Caddy como gateway?** El enrutado es deliberadamente simple, dos
+> destinos y una regla (`/api/*` → backend, todo lo demás → frontend), y la
+> autenticación vive en la API (JWT en una cookie httpOnly), no en el borde. Un
+> binario pequeño con una configuración mínima encaja con eso; los gateways
+> programables más pesados (Envoy, Kong) se ganan su sitio con muchos servicios y
+> validación de claves en el borde, que este stack no necesita. El gateway está
+> aislado en el servicio `proxy`, así que cambiarlo más adelante no toca nada más.
 
-2. El gateway escucha en `${WEB_PORT}` (por defecto `3000`), enlazado a `127.0.0.1`. Apunta tu proxy inverso a `127.0.0.1:3000`. Como la app y la API comparten un mismo origen, redirige el **dominio completo** a ese único puerto.
-3. Configura `COOKIE_SECURE=true` en `.env.docker` y reinicia, para que la cookie de sesión solo se envíe por TLS.
+## Contenido
 
-Mantén la base de datos, la API y el puente de WhatsApp privados dejando `BIND_HOST=127.0.0.1` (el valor por defecto); solo tu proxy inverso debe estar expuesto a internet. Para la lista completa de variables consulta [Configuración](configuration.md).
+- [Antes de empezar](#antes-de-empezar)
+- [Instalación](#instalación)
+- [Acceder a tu instalación](#acceder-a-tu-instalación)
+- [Asegurar tu instalación](#asegurar-tu-instalación)
+- [Pasar a producción (HTTPS)](#pasar-a-producción-https)
+- [Variables de entorno](#variables-de-entorno)
+- [Gestionar tu instalación](#gestionar-tu-instalación)
+- [Datos persistentes](#datos-persistentes)
+- [Copias de seguridad](#copias-de-seguridad)
+- [Actualizar](#actualizar)
+- [Desinstalar](#desinstalar)
+- [Correr sin Docker](#correr-sin-docker)
+- [Conectar WhatsApp](#conectar-whatsapp)
+- [Tests](#tests)
+- [Advertencias de WhatsApp / Baileys](#advertencias-de-whatsapp--baileys)
+- [Resolución de problemas](#resolución-de-problemas)
 
-Un ejemplo mínimo con Caddy en el host:
+## Antes de empezar
+
+Necesitas una máquina con Docker:
+
+- macOS / Windows: [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+- Linux o un servidor: Docker Engine con el plugin de Compose.
+
+Comprueba que está corriendo:
+
+```bash
+docker --version
+docker compose version
+```
+
+Para un despliegue público necesitas además un **dominio** y un servidor con los
+puertos **80** y **443** abiertos (mira [Pasar a producción](#pasar-a-producción-https)).
+
+## Instalación
+
+```bash
+git clone <REPOSITORY_URL>
+cd openlivery
+./scripts/generate-docker-env.sh   # writes .env.docker with random secrets (gitignored)
+make up                            # build, start, run migrations
+```
+
+`make up` construye las imágenes, arranca los contenedores, crea la base de datos
+y aplica las migraciones de Alembic. Todos los servicios deberían reportar
+`healthy`:
+
+```bash
+make ps
+```
+
+Sobrescribe los puertos del host cuando choquen con otros servicios:
+
+```bash
+API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up
+```
+
+### Arrancar desde imágenes precompiladas (sin build local)
+
+En cada push a `main` se publican imágenes etiquetadas en el GitHub Container
+Registry, así que un servidor puede saltarse el build y descargarlas:
+
+```bash
+make pull        # docker compose pull + up -d
+```
+
+Esto descarga `ghcr.io/sarrazola/openlivery-{api,web,whatsapp}:latest`. Fija una
+versión con `OPENLIVERY_VERSION=v1.2.3 make pull`, o apunta a tu propio registro
+con `OPENLIVERY_IMAGE_PREFIX`. La imagen `web` precompilada llama a la API a
+través del gateway con un `/api` relativo; para apuntar a una API en otro origen
+tienes que construir el frontend tú mismo con `NEXT_PUBLIC_API_URL` definida.
+
+## Acceder a tu instalación
+
+- **App y panel**: http://localhost:3000 (el gateway)
+- **Documentación de la API**: http://localhost:8000/docs (la API se expone en local para herramientas)
+- **PostgreSQL**: `make shell-db` (o conéctate a `localhost:5432`)
+
+En la primera pantalla elige **Crear agencia**; esa cuenta es la administradora.
+Solo el gateway está pensado para ser alcanzable públicamente; el web, la API, la
+base de datos y el puente de WhatsApp se quedan en la red privada de Compose.
+
+## Asegurar tu instalación
+
+Haz esto antes de exponer OpenLivery a alguien más.
+
+- **Secretos.** `generate-docker-env.sh` rellena `SECRET_KEY`, `ENCRYPTION_KEY`,
+  `WHATSAPP_BRIDGE_TOKEN` y `POSTGRES_PASSWORD` con valores aleatorios. Si los
+  pones a mano, usa cadenas largas y aleatorias, y nunca las reutilices entre
+  instalaciones.
+- ⚠️ **`ENCRYPTION_KEY` no debe cambiar nunca** una vez que hay secretos
+  guardados: es la que descifra las claves de los proveedores y las sesiones de
+  WhatsApp. Perderla o cambiarla las vuelve irrecuperables.
+- **Mantén los servicios privados.** Deja `BIND_HOST=127.0.0.1` (el valor por
+  defecto) para que la base de datos, la API y el frontend solo sean alcanzables
+  desde el host; expón la aplicación a internet **únicamente** a través del proxy
+  inverso (siguiente sección). Nunca publiques el puerto de PostgreSQL en una
+  interfaz pública.
+- **No subas `.env.docker`** al repositorio, ni ninguna copia de seguridad que lo
+  contenga; guárdalo en un gestor de secretos.
+- Las claves de los proveedores se cifran en reposo y nunca se devuelven enteras
+  al navegador; el estado de autenticación de WhatsApp y el QR también van
+  cifrados. `WHATSAPP_BRIDGE_TOKEN` autentica las llamadas privadas entre el
+  backend y el puente: no lo reutilices como contraseña ni como clave.
+- **Límite de peticiones.** Los endpoints públicos sin autenticar están limitados
+  por IP del cliente: inicio de sesión y registro (de agencia y de portal) para
+  frenar la fuerza bruta, y el endpoint de mensajes del widget web porque cada
+  llamada gasta tokens del modelo. Los límites viven en memoria (suficiente para
+  una instancia); pon `RATE_LIMIT_ENABLED=false` si el proxy de delante ya los
+  aplica, o añade límites a nivel de proxy en un despliegue escalado. El limitador
+  lee el cliente de `X-Forwarded-For`, que el gateway rellena.
+
+## Pasar a producción (HTTPS)
+
+El stack sirve HTTP plano en el gateway. Para un despliegue público, pon **tu
+propio proxy inverso** (Caddy, nginx, Traefik, un balanceador de tu nube…)
+delante del gateway para terminar TLS con tu dominio, que es el modelo habitual
+de autoalojamiento.
+
+1. Levanta el stack; el gateway escucha en `${WEB_PORT}` (por defecto `3000`),
+   atado a `127.0.0.1`.
+2. Apunta tu proxy inverso a `127.0.0.1:${WEB_PORT}` y sirve tu dominio por
+   HTTPS. Como la app y la API comparten origen, pasa el **dominio entero** a ese
+   único puerto: no hay nada más que enrutar.
+3. Pon `COOKIE_SECURE=true` en `.env.docker` y reinicia, para que la cookie de
+   sesión solo viaje por TLS.
+
+Ejemplo con Caddy (HTTPS automático) corriendo en el host:
 
 ```caddyfile
 agency.example.com {
@@ -30,20 +167,114 @@ agency.example.com {
 }
 ```
 
+Mantén privados la base de datos, la API y el puente de WhatsApp
+(`BIND_HOST=127.0.0.1`, el valor por defecto); solo tu proxy inverso debería dar
+la cara a internet.
+
+## Dominios propios para los portales de cliente
+
+Por defecto el portal de un cliente vive en `tu-dominio/portal/<slug>`. También
+puedes servirlo bajo el **dominio del propio cliente** (por ejemplo
+`chat.marca.com`) para una experiencia de marca blanca completa. Es opcional
+porque exige que el gateway termine TLS y obtenga certificados bajo demanda.
+
+**1. Habilita el gateway multidominio.** Crea un `docker-compose.override.yml`
+junto a `docker-compose.yml` (Compose lo combina automáticamente):
+
+```yaml
+services:
+  proxy:
+    volumes:
+      - ./docker/Caddyfile.ondemand:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data          # persist issued certificates across restarts
+    environment:
+      PRIMARY_DOMAIN: app.youragency.com   # your main domain
+    ports:
+      - "80:80"
+      - "443:443"
+
+volumes:
+  caddy_data:
+```
+
+Apunta `app.youragency.com` (y cada dominio de cliente) a este servidor, y
+después `make up`. El gateway obtiene el certificado del dominio principal de la
+manera normal, y el de cada dominio de cliente **bajo demanda**, pero solo
+después de preguntarle a la API si ese dominio es un dominio de portal verificado
+(`/api/public/portal-domain`), así que nunca emite certificados para hosts
+arbitrarios apuntados a tu IP.
+
+**2. Añade el dominio de un cliente.** En el panel abre el cliente → pestaña
+**Portal** → **Dominio propio**, escribe el dominio y guarda. Crea los dos
+registros DNS que te muestra:
+
+| Tipo | Host | Valor |
+| --- | --- | --- |
+| `CNAME` | `chat.marca.com` | el host de tu gateway (por ejemplo `app.youragency.com`) |
+| `TXT` | `_openlivery-challenge.chat.marca.com` | el token que se muestra |
+
+Pulsa **Verificar**. Cuando encuentre el registro TXT, el dominio queda marcado
+como verificado, el gateway empieza a emitir su certificado y el frontend enruta
+el dominio al portal de ese cliente. El portal tiene que estar **publicado** para
+que el dominio sirva algo.
+
+> Sin el override, la app se queda de origen único detrás de tu propio proxy
+> inverso, y los portales solo son alcanzables en `/portal/<slug>`.
+
+## Variables de entorno
+
+`generate-docker-env.sh` rellena los secretos. Para poner los valores a mano,
+copia `.env.docker.example` a `.env.docker` y reemplaza cada `CHANGE_*`.
+
+| Variable | Ámbito | Uso |
+| --- | --- | --- |
+| `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | Red privada | Base de datos PostgreSQL principal. |
+| `POSTGRES_TEST_DB` | Red privada | Base de datos aislada para `pytest`. |
+| `SECRET_KEY` | Backend | Firma las sesiones de agencia y de portal. |
+| `ENCRYPTION_KEY` | Backend / datos persistidos | Cifra las claves de API, el QR y la sesión de WhatsApp. **No debe cambiar** una vez guardados los secretos. |
+| `WHATSAPP_BRIDGE_TOKEN` | Backend y puente | Autentica las llamadas privadas entre backend y puente. |
+| `FRONTEND_URL` | Backend | Origen permitido por CORS (solo hace falta si sirves la API en otro origen). |
+| `NEXT_PUBLIC_API_URL` | Navegador / build del frontend | Déjala vacía (por defecto): el navegador llama a la API por el gateway con un `/api` relativo. Ponla solo para apuntar el frontend a una API en otro origen (se fija en tiempo de build). |
+| `COOKIE_SECURE` | Backend | `true` detrás de HTTPS, para que la cookie de sesión solo viaje por TLS. |
+| `COOKIE_SAMESITE` | Backend | `lax` (por defecto); `none` cuando frontend y API están en sitios distintos (exige `COOKIE_SECURE=true`). |
+| `ACCESS_TOKEN_MINUTES` | Backend | Duración de la sesión. |
+| `WHATSAPP_LOG_LEVEL` | Puente | Nivel de log; `silent` evita exponer datos sensibles. |
+| `API_PORT`, `WEB_PORT`, `DB_PORT` | Host | Puertos del host (por defecto `8000` / `3000` / `5432`). |
+| `BIND_HOST` | Host | Dirección de escucha: `127.0.0.1` (local) o `0.0.0.0` (exposición directa). |
+
+## Gestionar tu instalación
+
+```bash
+make logs                 # follow logs from all services (SERVICE=api to filter)
+make ps                   # service status
+make stop                 # stop containers (keep them)
+make start                # start stopped containers
+make restart              # restart all services
+make migrate              # apply Alembic migrations in the running api container
+make shell-api            # shell inside the api container
+make shell-db             # psql inside the database
+make down                 # stop and remove containers (keeps data volumes)
+```
+
+Ejecuta `make help` para la lista completa.
+
 ## Datos persistentes
 
-Todo el estado vive en volúmenes de Docker con nombre, por lo que `make down` y las actualizaciones lo conservan:
+Todo el estado vive en volúmenes de Docker con nombre, así que `make down` y las
+actualizaciones lo conservan:
 
 | Volumen | Contenido |
 | --- | --- |
-| `postgres_data` | La base de datos PostgreSQL — agencias, agentes, conversaciones, claves de proveedor cifradas y el estado cifrado de la sesión de WhatsApp. |
-| `backend_storage` | Archivos subidos (por ejemplo, los PDF de la base de conocimiento). |
+| `postgres_data` | La base de datos PostgreSQL: agencias, agentes, conversaciones, claves de proveedores cifradas y el estado cifrado de las sesiones de WhatsApp. |
+| `backend_storage` | Archivos subidos (por ejemplo los PDF de la base de conocimiento). |
 
-La `ENCRYPTION_KEY` descifra las claves de API de los proveedores y las sesiones de WhatsApp. **Nunca la cambies** una vez almacenados los secretos, o quedarán irrecuperables — trátala como parte de tu copia de seguridad.
+`ENCRYPTION_KEY` descifra las claves de los proveedores y las sesiones de
+WhatsApp. **No la cambies nunca** una vez que hay secretos guardados, o quedan
+irrecuperables; trátala como parte de tu copia de seguridad.
 
-## Copias de seguridad y restauración
+## Copias de seguridad
 
-Exporta PostgreSQL sin detener la app:
+Exporta PostgreSQL sin parar la aplicación:
 
 ```bash
 mkdir -p backups
@@ -51,7 +282,11 @@ docker compose --env-file .env.docker exec -T db \
   sh -c 'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc' > backups/openlivery.dump
 ```
 
-Guarda también `.env.docker` en un gestor de secretos: un volcado con claves de API o una sesión de WhatsApp necesita la misma `ENCRYPTION_KEY` para descifrarse. Restaura (reemplaza los datos de la base de datos de destino — haz una copia antes):
+Guarda también `.env.docker` en un gestor de secretos: una copia con claves de
+API o una sesión de WhatsApp necesita la misma `ENCRYPTION_KEY` para poder
+descifrarse.
+
+Restaurar (reemplaza los datos de la base de destino, haz copia antes):
 
 ```bash
 docker compose --env-file .env.docker stop api whatsapp
@@ -60,24 +295,30 @@ docker compose --env-file .env.docker exec -T db \
 docker compose --env-file .env.docker start api whatsapp
 ```
 
-## Actualizaciones
-
-Descarga la nueva versión y reconstruye — los volúmenes de datos quedan intactos:
+## Actualizar
 
 ```bash
 git pull
-make up        # reconstruye y reinicia; tu proxy inverso sigue por delante
+make up        # rebuilds and restarts; your reverse proxy stays in front
 ```
 
-El backend ejecuta `alembic upgrade head` al arrancar, por lo que los cambios de esquema se aplican sin borrar `postgres_data`. ¿Ejecutas desde imágenes prediseñadas? Usa `make pull` (fija una versión con `OPENLIVERY_VERSION=v1.2.3 make pull`). Haz una copia de seguridad antes.
+Se construyen las imágenes nuevas y el backend ejecuta `alembic upgrade head` al
+arrancar, así que los cambios de esquema se aplican solos. Haz una copia de
+seguridad antes.
 
-## Dominios personalizados para portales de cliente
+## Desinstalar
 
-Por defecto el portal de un cliente vive en `tu-dominio/portal/<slug>`. También puedes servirlo bajo el dominio propio del cliente con TLS bajo demanda, un override opcional que monta `docker/Caddyfile.ondemand` y publica los puertos 80/443 en el gateway. El recorrido completo — el `docker-compose.override.yml`, los registros DNS y la verificación — está en [Portal de cliente](client-portal.md).
+`make down` elimina los contenedores y la red, pero conserva tus datos. Para
+borrar **todo** (base de datos, PDF, claves y sesiones de WhatsApp en los
+volúmenes):
 
-## Ejecutar sin Docker
+```bash
+make destroy   # irreversible
+```
 
-Para una configuración local sin contenedores ejecutas cada servicio a mano. Requisitos: Python 3.12+, Node.js 20+, PostgreSQL 14+.
+## Correr sin Docker
+
+Requisitos: Python 3.12+, Node.js 20+ y PostgreSQL 14+ en marcha.
 
 ```bash
 # 1) databases
@@ -100,12 +341,77 @@ cd apps/web && npm install && npm run dev
 cd apps/whatsapp && npm install && npm run start
 ```
 
-El puente escucha solo en `127.0.0.1:3101` y debe seguir en ejecución junto al backend. Consulta `.env.example` para la lista completa de variables (`DATABASE_URL`, `BACKEND_URL`, `WHATSAPP_BRIDGE_URL`, `WHATSAPP_BRIDGE_PORT`, …).
+El puente escucha solo en `127.0.0.1:3101` y tiene que quedarse corriendo junto
+al backend. Mira `.env.example` para la lista completa de variables
+(`DATABASE_URL`, `BACKEND_URL`, `WHATSAPP_BRIDGE_URL`, `WHATSAPP_BRIDGE_PORT`…).
 
-## Solución de problemas
+## Conectar WhatsApp
 
-- **Puertos ya en uso.** Sobrescríbelos en línea: `API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up`.
-- **Un servicio está unhealthy.** Revisa sus logs con `make logs SERVICE=api` (o `web`, `whatsapp`, `db`) y `make ps` para ver el estado.
-- **La sesión no persiste / bucle de inicio de sesión tras HTTPS.** Asegúrate de que `COOKIE_SECURE=true` está configurado y de que accedes a la app por TLS.
-- **Las claves de proveedor o la sesión de WhatsApp dejaron de descifrarse.** La `ENCRYPTION_KEY` cambió — restaura el valor original desde tu copia de seguridad.
-- **WhatsApp pide un nuevo QR tras reiniciar.** Es normal solo si WhatsApp terminó la sesión, se desvinculó el dispositivo o cambió la `ENCRYPTION_KEY`; de lo contrario el puente recarga las sesiones habilitadas desde PostgreSQL automáticamente.
+1. Abre **Clientes → el cliente → Canales → WhatsApp → Configurar**.
+2. Elige uno de los agentes de ese cliente y pulsa **Conectar con código QR**.
+3. En el teléfono: **WhatsApp → Ajustes → Dispositivos vinculados → Vincular un
+   dispositivo**, escanea el QR y espera a **Conectado**.
+
+Los mensajes entrantes aparecen en el **Inbox** de la agencia y en el portal del
+cliente. Pulsa **Tomar la conversación** para responder como persona (la IA se
+pausa) y **Devolver a la IA** para continuar. Al reiniciar, el puente recarga las
+sesiones activas desde PostgreSQL y se reconecta automáticamente: no hace falta
+un QR nuevo salvo que WhatsApp termine la sesión, se desvincule el dispositivo o
+cambie `ENCRYPTION_KEY`.
+
+## Tests
+
+Dentro de Docker:
+
+```bash
+make test   # backend pytest + rebuild the web/whatsapp validation stages
+```
+
+En local:
+
+```bash
+cd apps/api && ../../.venv/bin/pytest -q     # backend (needs the openlivery_test DB)
+cd apps/whatsapp && npm test && npm run build
+cd apps/web && npm run lint && npm run build
+```
+
+Volver a probar las migraciones desde cero:
+
+```bash
+cd apps/api && alembic downgrade base && alembic upgrade head
+```
+
+## Advertencias de WhatsApp / Baileys
+
+Baileys se conecta al protocolo multidispositivo de **WhatsApp Web**; el número
+se vincula como un dispositivo más mediante QR. **No** es la API oficial de
+WhatsApp Business Cloud, y este proyecto no está afiliado ni respaldado por
+WhatsApp ni por Meta.
+
+- WhatsApp puede cambiar su protocolo o revocar una sesión o un dispositivo sin
+  avisar.
+- La automatización abusiva, el spam o los envíos masivos pueden hacer que
+  restrinjan un número. Usa solo números autorizados por cada cliente y respeta
+  los términos de WhatsApp.
+- El QR vincula la cuenta mientras es válido: nunca lo compartas ni publiques una
+  captura.
+- La integración maneja conversaciones uno a uno (texto, más notas de voz
+  transcritas e imágenes descritas cuando las capacidades del agente están
+  activas). Ignora grupos, estados, canales, documentos, ubicaciones, reacciones
+  y llamadas.
+- Una cuenta de WhatsApp pertenece a un cliente; otro cliente necesita otro
+  número. `apps/whatsapp/package.json` fija una versión exacta de Baileys.
+
+## Resolución de problemas
+
+- **Puertos ocupados.** Sobrescríbelos en la misma línea:
+  `API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up`.
+- **Un servicio no está sano.** Revisa sus logs con `make logs SERVICE=api` (o
+  `web`, `whatsapp`, `db`) y `make ps` para ver el estado.
+- **La sesión no persiste, o el login entra en bucle detrás de HTTPS.** Asegúrate
+  de tener `COOKIE_SECURE=true` y de estar llegando a la app por TLS.
+- **Las claves de proveedor o la sesión de WhatsApp dejaron de descifrarse.**
+  Cambió `ENCRYPTION_KEY`: restaura el valor original desde tu copia.
+- **WhatsApp pide un QR nuevo tras reiniciar.** Solo es normal si WhatsApp
+  terminó la sesión, se desvinculó el dispositivo o cambió `ENCRYPTION_KEY`; si
+  no, el puente recarga solo las sesiones activas desde PostgreSQL.

--- a/docs/es/web-widget.md
+++ b/docs/es/web-widget.md
@@ -1,0 +1,41 @@
+# Widget de chat web
+
+> Read in English: [web-widget.md](../en/web-widget.md)
+
+El widget web es un chat embebible, respaldado por uno de tus agentes, que puedes colocar en cualquier sitio web con una sola etiqueta `<script>`. Los visitantes ven un botón de chat flotante; al abrirlo hablan con el agente a través de la API pública de OpenLivery, con el mismo conocimiento e instrucciones que configuraste.
+
+## Cómo funciona
+
+Cada agente tiene un `widget_public_id`: un identificador público que se usa en la ruta del widget `/widget/<publicId>`. El script de carga monta un `iframe` que apunta a esa ruta y añade un botón lanzador flotante. Como el id es público, el widget se sirve sin autenticación, así que nunca se expone al navegador nada sensible (claves de API, datos de otros clientes).
+
+El widget solo funciona mientras está habilitado: el backend sirve los endpoints de configuración, historial y mensajes únicamente para agentes en los que `widget_enabled` está activo. Publica y habilita el agente antes de embeberlo.
+
+## Habilitar y obtener el fragmento
+
+1. Abre el agente y ve a la pestaña **Widget**.
+2. Activa **Habilitar widget** y define el saludo, el color y la posición (izquierda o derecha).
+3. Guarda y copia el fragmento de inserción desde la sección **Embed**. Un enlace de **Vista previa** abre el widget de forma independiente.
+
+El fragmento apunta `data-agent` al id público del agente y pasa las opciones de apariencia como atributos de datos:
+
+```html
+<script
+  src="https://your-openlivery-domain/widget.js"
+  data-agent="AGENT_PUBLIC_ID"
+  data-color="#075985"
+  data-position="right"
+  async
+></script>
+```
+
+Pégalo antes de la etiqueta de cierre `</body>` de cualquier página. El origen de `src` debe ser tu despliegue de OpenLivery; `widget.js` deriva la URL del iframe de su propio origen.
+
+## Mensajes y límite de peticiones
+
+Cuando un visitante envía un mensaje, el widget llama al endpoint público `POST /api/widget/<publicId>/messages` con un `session_id` por navegador. El backend localiza el agente, añade el mensaje a una conversación `widget`, recupera el conocimiento, llama al proveedor configurado y devuelve la respuesta. El historial de la sesión se guarda en el `localStorage` del visitante, de modo que la conversación sobrevive a las recargas de página.
+
+Estos endpoints públicos tienen límite de peticiones por IP de cliente (30 peticiones de mensaje por minuto) porque cada llamada consume tokens del LLM. Quien supere el límite recibe `429 Too Many Requests` con una cabecera `Retry-After`. El limitador lee la IP del cliente desde `X-Forwarded-For` que establece el gateway. Consulta [Configuración](configuration.md) para el interruptor `RATE_LIMIT_ENABLED`.
+
+## Conversaciones del widget en el inbox
+
+Cada chat del widget se convierte en una conversación del canal `widget`, así que aparece en el [Inbox](inbox.md) junto a los hilos de WhatsApp y del playground. Puedes filtrar por el canal del widget, leer la transcripción completa y cambiar una conversación a modo **humano**, lo que pausa la IA para que un operador responda directamente desde el portal.

--- a/docs/es/whatsapp-cloud-api.md
+++ b/docs/es/whatsapp-cloud-api.md
@@ -1,6 +1,6 @@
 # Conectar la API de WhatsApp Business Cloud
 
-> Read in English: [whatsapp-cloud-api.md](whatsapp-cloud-api.md)
+> Read in English: [whatsapp-cloud-api.md](../en/whatsapp-cloud-api.md)
 
 Esta guía explica cómo conectar el número de WhatsApp de un cliente a
 OpenLivery usando la **API oficial de WhatsApp Business Cloud** (alojada por

--- a/docs/es/whatsapp.md
+++ b/docs/es/whatsapp.md
@@ -1,0 +1,44 @@
+# WhatsApp
+
+> Read in English: [whatsapp.md](../en/whatsapp.md)
+
+OpenLivery conecta un número real de WhatsApp a cada cliente para que su agente responda las conversaciones automáticamente. Cada cliente tiene su propia sesión, vinculada al escanear un código QR desde la app móvil de WhatsApp, sin necesidad de una cuenta de la WhatsApp Business API.
+
+## El servicio puente
+
+El soporte de WhatsApp corre en un servicio dedicado, el **puente** (`apps/whatsapp/`), un proceso de Node.js con estado construido sobre [Baileys](https://github.com/WhiskeySockets/Baileys), el protocolo de WhatsApp Web. El puente mantiene un socket activo por cada cliente conectado y se comunica con el backend a través de una API interna.
+
+Como tiene estado, el puente no guarda las sesiones solo en memoria: el estado de sesión y autenticación se almacena cifrado a través del backend en PostgreSQL. Al arrancar, el puente pide al backend la lista de canales habilitados que ya tienen una sesión guardada y los recarga, de modo que los números se reconectan solos tras un reinicio.
+
+## Conectar un número
+
+Una sesión de WhatsApp pertenece a un solo cliente. Para conectarla:
+
+1. Abre un **cliente**, ve a su canal de **WhatsApp** y elige el agente que responderá los mensajes entrantes.
+2. Pulsa conectar. El backend le pide al puente iniciar una sesión y aparece un **código QR**.
+3. En el teléfono dueño del número, abre WhatsApp y ve a **Ajustes → Dispositivos vinculados → Vincular un dispositivo**.
+4. Escanea el código QR. Cuando el teléfono lo confirme, el canal cambia a **conectado** y muestra el número vinculado.
+
+A partir de ahí la sesión sobrevive a los reinicios. Si el número se desvincula desde el teléfono (o la sesión se invalida), el puente borra el estado de autenticación guardado y el canal vuelve a desconectado. También puedes desconectar desde la misma página, lo que cierra la sesión del dispositivo y elimina la sesión guardada.
+
+## Cómo fluyen los mensajes
+
+Cuando un contacto escribe al número:
+
+1. El puente recibe el mensaje y lo reenvía al backend en `POST /api/whatsapp/channels/{channel_id}/inbound`.
+2. El backend registra el mensaje en la conversación del cliente, recupera el conocimiento del agente y genera una respuesta con el agente asignado.
+3. La respuesta se envía de vuelta al contacto en WhatsApp a través del puente.
+
+Las imágenes y las notas de voz también se reenvían; cuando el agente tiene habilitada la comprensión de imagen o audio, se describen o transcriben antes de llegar al modelo. Consulta [Base de conocimiento](knowledge-base.md).
+
+El backend y el puente se autentican en cada llamada entre sí con un secreto compartido, `WHATSAPP_BRIDGE_TOKEN`. El script de instalación lo genera por ti; consulta [Configuración](configuration.md).
+
+## Intervención humana
+
+Cada conversación tiene un `mode`, que es `ai` (el valor por defecto) o `human`. Cuando cambias una conversación al modo human, la IA deja de responderla —el backend sigue registrando los mensajes entrantes, pero no genera ninguna respuesta automática— para que una persona pueda tomar el control y responder directamente desde la [bandeja de entrada](inbox.md) o el [portal del cliente](client-portal.md). Vuelve a `ai` para devolver la conversación al agente.
+
+## Otros canales
+
+WhatsApp es el único canal de mensajería en el núcleo open source por ahora. Instagram y Facebook Messenger están en la hoja de ruta.
+
+Siguiente: gestiona las conversaciones en vivo en la [bandeja de entrada](inbox.md) o deja que los clientes gestionen las suyas en el [portal del cliente](client-portal.md).


### PR DESCRIPTION
The guides lived in a separate, private website repository. Someone contributing
here could read them at openlivery.com but could not open a pull request against
them, so a change to the product and the change to its documentation could not
travel together.

They drifted, and the drift is measurable. This repository already carried a
367-line self-hosting guide against the 107 lines that were published, plus a
bilingual WhatsApp Cloud API guide and a push notifications guide that were never
published at all. Roughly 400 lines written here had no reader.

## What this does

The fourteen published guides arrive as plain markdown under `docs/en` and
`docs/es`, keeping their slugs. The three that only ever existed here join them in
the same layout. `docs/README.md` carries the navigation, titles and descriptions
the website's `lib/docs.ts` used to own.

Each file regains the H1 the site rendered from that manifest, and gets a link to
its translation. Internal links become relative so they resolve on GitHub.

The two self-hosting guides are merged rather than one being picked. This one was
the fuller of the two and gains the **Persistent data** and **Troubleshooting**
sections the published version had and it lacked.

Both languages now carry the same guide: self-hosting went from 111 Spanish lines
to 417, and push notifications gained the Spanish the index was already linking
to. Code, commands, identifiers and environment variables stay English in both.

The README stops sending readers to the website for guides it can now link
directly.

## Checks

Every internal link and every in-page anchor across the 34 markdown files
resolves; the 16 guides exist in both languages with no orphans on either side.

Nothing renders these yet, which is the point: markdown on GitHub is where a
contributor reads and edits them. A follow-up removes the docs section from the
website.