### PR TITLE
Answer only the number a WhatsApp Cloud channel owns

### DIFF
--- a/apps/api/app/routers/whatsapp_cloud.py
+++ b/apps/api/app/routers/whatsapp_cloud.py
@@ -77,6 +77,20 @@ def configure_channel(
     )
     if not agent:
         raise HTTPException(status_code=400, detail="Select an agent that belongs to this client")
+    # One number answers for one client. Saving the same one twice would give
+    # two agents the same inbox, and each channel's webhook would accept the
+    # other's traffic.
+    number = (payload.phone_number_id or "").strip()
+    if number and db.scalar(
+        select(WhatsAppCloudChannel).where(
+            WhatsAppCloudChannel.agency_id == user.agency_id,
+            WhatsAppCloudChannel.phone_number_id == number,
+            WhatsAppCloudChannel.client_id != client.id,
+        )
+    ):
+        raise HTTPException(
+            status_code=400, detail="That phone number is already connected to another client"
+        )
     channel = db.scalar(select(WhatsAppCloudChannel).where(WhatsAppCloudChannel.client_id == client.id))
     if not channel:
         channel = WhatsAppCloudChannel(
@@ -89,7 +103,7 @@ def configure_channel(
     channel.agent_id = agent.id
     channel.is_enabled = True
     if payload.phone_number_id is not None:
-        channel.phone_number_id = payload.phone_number_id.strip()
+        channel.phone_number_id = number
     if payload.waba_id is not None:
         channel.waba_id = payload.waba_id.strip() or None
     # Blank secrets keep the stored values, so the form can resubmit safely.

--- a/apps/api/app/routers/whatsapp_cloud_webhook.py
+++ b/apps/api/app/routers/whatsapp_cloud_webhook.py
@@ -110,6 +110,19 @@ async def receive_webhook(channel_id: uuid.UUID, request: Request, db: Session =
             if change.get("field") != "messages":
                 continue
             value = change.get("value") or {}
+            # A Meta app has one callback URL, so an app serving several
+            # channels delivers all of their traffic to whichever one was
+            # registered. Without this the messages of one client would be
+            # answered as another: same agency, wrong number, wrong agent.
+            # Each channel needs its own Meta app.
+            delivered_to = (value.get("metadata") or {}).get("phone_number_id")
+            if channel.phone_number_id and delivered_to and delivered_to != channel.phone_number_id:
+                logger.warning(
+                    "channel %s received traffic for phone number %s, which belongs to another channel",
+                    channel.id,
+                    delivered_to,
+                )
+                continue
             for status in value.get("statuses") or []:
                 _record_status(db, channel, status)
             contacts = {

--- a/apps/api/tests/test_whatsapp_cloud.py
+++ b/apps/api/tests/test_whatsapp_cloud.py
@@ -23,7 +23,9 @@ def _sign(raw: bytes, secret: str = APP_SECRET) -> str:
     return "sha256=" + hmac.new(secret.encode(), raw, hashlib.sha256).hexdigest()
 
 
-def _webhook_payload(messages: list[dict], contacts: list[dict] | None = None) -> dict:
+def _webhook_payload(
+    messages: list[dict], contacts: list[dict] | None = None, phone_number_id: str = "111"
+) -> dict:
     return {
         "object": "whatsapp_business_account",
         "entry": [
@@ -34,7 +36,7 @@ def _webhook_payload(messages: list[dict], contacts: list[dict] | None = None) -
                         "field": "messages",
                         "value": {
                             "messaging_product": "whatsapp",
-                            "metadata": {"phone_number_id": "111"},
+                            "metadata": {"phone_number_id": phone_number_id},
                             "contacts": contacts or [],
                             "messages": messages,
                         },
@@ -443,3 +445,69 @@ def test_webhook_image_uses_capability(authenticated_client: TestClient, monkeyp
     assert detail["messages"][0]["attachments"][0]["kind"] == "image"
     prompt_messages = fake_completion.await_args.args[4]
     assert any("a photo of the menu" in message["content"] for message in prompt_messages)
+
+
+def test_webhook_ignores_traffic_for_a_number_that_is_not_this_channels(
+    authenticated_client: TestClient, monkeypatch
+):
+    """One Meta app has one callback URL, so an app shared between channels
+    delivers every number's traffic to whichever channel registered it."""
+    client = authenticated_client
+    _customer, _agent, channel = _setup_channel(client)
+    fake_completion = AsyncMock(return_value=ai_service.Completion(text="Hi"))
+    monkeypatch.setattr(whatsapp_inbound_service, "run_completion", fake_completion)
+    monkeypatch.setattr(webhook_router, "send_text", AsyncMock(return_value="wamid.out-1"))
+    monkeypatch.setattr(whatsapp_inbound_service, "mark_read_with_typing", AsyncMock())
+
+    other = _webhook_payload(
+        [{"from": "5730011", "id": "wamid.other", "type": "text", "text": {"body": "Hola"}}],
+        phone_number_id="999",
+    )
+    assert _post_signed(client, channel["id"], other).status_code == 200
+    assert fake_completion.await_count == 0
+    assert client.get("/api/conversations").json() == []
+
+    # The channel's own number still goes through.
+    mine = _webhook_payload(
+        [{"from": "5730011", "id": "wamid.mine", "type": "text", "text": {"body": "Hola"}}]
+    )
+    assert _post_signed(client, channel["id"], mine).status_code == 200
+    assert fake_completion.await_count == 1
+
+
+def test_configure_channel_refuses_a_number_another_client_uses(authenticated_client: TestClient):
+    client = authenticated_client
+    _setup_channel(client)
+
+    other = client.post(
+        "/api/clients",
+        json={"name": "Cafe", "industry": "", "description": "", "general_context": "", "is_active": True},
+    ).json()
+    agent = client.post(
+        "/api/agents",
+        json={
+            "client_id": other["id"],
+            "provider": "openai",
+            "model": "gpt-4.1-mini",
+            "name": "Host",
+            "description": "",
+            "instructions": "",
+            "personality": "",
+            "is_active": True,
+        },
+    ).json()
+
+    taken = client.put(
+        f"/api/whatsapp-cloud/channels/{other['id']}",
+        json={"agent_id": agent["id"], "phone_number_id": "111"},
+    )
+    assert taken.status_code == 400
+    assert "another client" in taken.json()["detail"]
+
+    # A different number is fine, and saving the same one again on its own
+    # client still is.
+    free = client.put(
+        f"/api/whatsapp-cloud/channels/{other['id']}",
+        json={"agent_id": agent["id"], "phone_number_id": "222"},
+    )
+    assert free.status_code == 200, free.text

--- a/docs/en/whatsapp-cloud-api.md
+++ b/docs/en/whatsapp-cloud-api.md
@@ -30,6 +30,11 @@ Before the technical setup, make sure you have:
   **not** currently registered on the WhatsApp/WhatsApp Business apps.
 - An OpenLivery instance reachable over **public HTTPS** (Meta only delivers
   webhooks to HTTPS URLs), with the client created and an agent assigned to it.
+- **One Meta app per client.** A Meta app has a single callback URL, and
+  OpenLivery gives each channel its own, so an app cannot serve two clients:
+  whichever URL you register is the only one that receives. Traffic arriving for
+  a number that does not belong to the channel is ignored rather than answered
+  by the wrong agent, so a shared app looks like messages never arriving.
 
 ## 2. Create the Meta app
 
@@ -130,8 +135,11 @@ Still on the channel page, OpenLivery shows a **Callback URL** and a
   the one OpenLivery shows exactly, and the callback URL must be reachable
   from the internet over HTTPS. On self-hosted instances, check that
   `FRONTEND_URL` points to the public address of the app.
-- **No messages arrive** — confirm the subscription to the **`messages`**
-  webhook field (step 7), and that the app is in **Live** mode; in
+- **No messages arrive** — confirm the number in the payload belongs to this
+  channel: an app shared between two clients delivers everything to a single
+  callback URL, and traffic for another number is dropped on purpose (see
+  [Prerequisites](#1-prerequisites)). Then confirm the subscription to the
+  **`messages`** webhook field (step 7), and that the app is in **Live** mode; in
   Development mode Meta only delivers traffic from test numbers. The channel
   card in OpenLivery shows the last webhook error, if any.
 - **Messages arrive but the agent does not answer** — the channel is

--- a/docs/es/whatsapp-cloud-api.md
+++ b/docs/es/whatsapp-cloud-api.md
@@ -31,6 +31,12 @@ Antes de la configuración técnica, asegúrate de tener:
   WhatsApp/WhatsApp Business.
 - Una instancia de OpenLivery accesible por **HTTPS público** (Meta solo
   entrega webhooks a URLs HTTPS), con el cliente creado y un agente asignado.
+- **Una app de Meta por cliente.** Una app de Meta tiene una sola URL de
+  callback, y OpenLivery le da la suya a cada canal, así que una app no puede
+  servir a dos clientes: la URL que registres es la única que recibe. El tráfico
+  que llega de un número que no es el del canal se ignora en vez de contestarlo
+  con el agente equivocado, así que una app compartida se ve como mensajes que
+  nunca llegan.
 
 ## 2. Crear la app de Meta
 
@@ -137,8 +143,11 @@ En la misma página del canal, OpenLivery muestra una **URL de callback** y un
   callback debe ser accesible desde internet por HTTPS. En instancias
   self-hosted, revisa que `FRONTEND_URL` apunte a la dirección pública de la
   app.
-- **No llegan mensajes** — confirma la suscripción al campo de webhook
-  **`messages`** (paso 7) y que la app esté en modo **Live**; en modo
+- **No llegan mensajes** — confirma que el número del payload es el de este
+  canal: una app compartida entre dos clientes entrega todo a una sola URL de
+  callback, y el tráfico de otro número se descarta a propósito (mira
+  [Requisitos previos](#1-requisitos-previos)). Después confirma la suscripción
+  al campo de webhook **`messages`** (paso 7) y que la app esté en modo **Live**; en modo
   Development Meta solo entrega tráfico de números de prueba. La tarjeta del
   canal en OpenLivery muestra el último error del webhook, si lo hay.
 - **Llegan mensajes pero el agente no responde** — el canal está conectado


### PR DESCRIPTION
Each channel gets its own callback URL (`/api/public/whatsapp-cloud/channels/<id>/webhook`), which quietly assumes each channel has its own Meta app.

A Meta app has a **single** callback URL. So an agency that points one app at several clients can only register one of them, and every client's traffic arrives there. The webhook verified the signature — which passes, because it is the same app — and then answered all of it as the channel that owns the URL.

The result: one client's customers, replied to by another client's agent, in another client's inbox. Nothing fails, nothing logs, and the conversation history looks legitimate on both sides.

One Meta app per client is a reasonable requirement. Failing silently when it is not met is not.

## What changes

**The webhook checks the number.** It compares `value.metadata.phone_number_id` against the channel's and skips changes that do not match, logging the mismatch. A shared app now looks like messages never arriving, which someone will notice and can diagnose, instead of messages answered as the wrong client, which nobody notices.

The check only applies when both sides are present, so a payload without metadata (a bare status callback, as one existing test sends) still goes through.

**Saving the same number twice is refused.** `UniqueConstraint("client_id")` means one client has one channel, but nothing stopped two channels from claiming the same number. Configuring one that another client in the agency already uses now returns 400. This is an application-level check rather than a constraint, so it needs no migration.

**The guide gains both**, in English and Spanish: the constraint in the prerequisites, and the symptom in troubleshooting, since sharing one app is the natural thing to try.

## Tests

Two added: the webhook ignoring traffic for a number that is not the channel's while still accepting its own, and the configure endpoint refusing a number another client holds while accepting a free one.

Full backend suite: 86 passed.