### PR TITLE
Accept SQLAlchemy-style postgres URLs for the session store

### DIFF
--- a/apps/whatsapp/main.go
+++ b/apps/whatsapp/main.go
@@ -59,11 +59,34 @@ func loadDotEnv() {
 	}
 }
 
-// openStore opens the whatsmeow session store. A postgres:// URL uses
-// Postgres (the search_path query parameter selects the schema, which is
-// created when missing); anything else is treated as a SQLite path.
+var postgresScheme = regexp.MustCompile(`^postgres(ql)?(\+[a-z0-9]+)?://`)
+
+// normalizeStoreURL turns any postgres-family URL into one lib/pq accepts:
+// SQLAlchemy-style schemes like postgresql+psycopg:// are common when the DSN
+// is shared with the backend. A non-empty schema lands in search_path unless
+// the URL already picked one.
+func normalizeStoreURL(storeURL, schema string) string {
+	if !postgresScheme.MatchString(storeURL) {
+		return storeURL
+	}
+	normalized := postgresScheme.ReplaceAllString(storeURL, "postgres://")
+	if schema != "" && !strings.Contains(normalized, "search_path=") {
+		separator := "?"
+		if strings.Contains(normalized, "?") {
+			separator = "&"
+		}
+		normalized += separator + "search_path=" + schema
+	}
+	return normalized
+}
+
+// openStore opens the whatsmeow session store. A postgres-family URL uses
+// Postgres (the search_path query parameter, or WHATSAPP_STORE_SCHEMA,
+// selects the schema, which is created when missing); anything else is
+// treated as a SQLite path.
 func openStore(ctx context.Context, storeURL string, log waLog.Logger) (*sqlstore.Container, error) {
-	if strings.HasPrefix(storeURL, "postgres://") || strings.HasPrefix(storeURL, "postgresql://") {
+	if postgresScheme.MatchString(storeURL) {
+		storeURL = normalizeStoreURL(storeURL, getenv("WHATSAPP_STORE_SCHEMA", ""))
 		ensureSchema(storeURL, log)
 		return sqlstore.New(ctx, "postgres", storeURL, log)
 	}

--- a/apps/whatsapp/store_test.go
+++ b/apps/whatsapp/store_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestNormalizeStoreURL(t *testing.T) {
+	cases := []struct{ in, schema, want string }{
+		{"postgres://u:p@h:5432/db", "", "postgres://u:p@h:5432/db"},
+		{"postgresql://u:p@h/db", "whatsmeow", "postgres://u:p@h/db?search_path=whatsmeow"},
+		{"postgresql+psycopg://u:p@h/db?sslmode=require", "whatsmeow", "postgres://u:p@h/db?sslmode=require&search_path=whatsmeow"},
+		{"postgres://u:p@h/db?search_path=other", "whatsmeow", "postgres://u:p@h/db?search_path=other"},
+		{"file:whatsmeow.db", "whatsmeow", "file:whatsmeow.db"},
+	}
+	for _, c := range cases {
+		if got := normalizeStoreURL(c.in, c.schema); got != c.want {
+			t.Fatalf("normalizeStoreURL(%q, %q) = %q, want %q", c.in, c.schema, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
A deployment that points WHATSAPP_STORE_URL at the same secret the backend uses gets a postgresql+psycopg:// DSN, which lib/pq rejects; worse, the prefix check misread it as a SQLite path. Normalize any postgres-family scheme to postgres:// and add WHATSAPP_STORE_SCHEMA to select the schema when the URL does not carry search_path, with unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k6uMcQ26x6si5xaYkskHR