### PR TITLE
Model pickers ask the API which models the workspace can use

### DIFF
--- a/apps/api/app/routers/catalog.py
+++ b/apps/api/app/routers/catalog.py
@@ -5,10 +5,18 @@ from fastapi import APIRouter, Depends, HTTPException
 from ..deps import get_current_user
 from ..models import User
 from ..schemas import ModelCatalogOut
+from ..services import model_catalog
 from ..services.model_catalog import get_model, list_models
 
 
 router = APIRouter(prefix="/catalog", tags=["Model catalog"])
+
+
+@router.get("/available")
+def available_models(user: User = Depends(get_current_user)):
+    """Model ids this workspace can pick, per provider and capability. A
+    module call on purpose, so a deployment can narrow the answer."""
+    return model_catalog.available_models()
 
 
 @router.get("/models", response_model=list[ModelCatalogOut])

--- a/apps/api/app/services/model_catalog.py
+++ b/apps/api/app/services/model_catalog.py
@@ -123,3 +123,23 @@ def get_model(model_id: str) -> ModelInfo | None:
 def estimate_tokens(text: str) -> int:
     """Quick token estimate (~4 characters per token)."""
     return (len(text) + CHARS_PER_TOKEN - 1) // CHARS_PER_TOKEN
+
+
+# Capability model lists the app offers (mirrored by the frontend as its
+# loading fallback in apps/web/lib/providers.ts). OpenAI only: audio and image
+# understanding run through the workspace's OpenAI credentials.
+AUDIO_MODELS = ("gpt-transcribe", "whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe", "gpt-4o-transcribe-diarize")
+IMAGE_MODELS = ("gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.5", "gpt-5.4", "gpt-4.1", "gpt-4.1-mini")
+
+
+def available_models() -> dict:
+    """Model ids a workspace can pick, per provider and capability.
+
+    A stock install offers the whole catalog. A deployment may narrow this
+    (for example to the models its managed credentials can actually serve),
+    which is why the frontend asks instead of trusting its static lists.
+    """
+    chat: dict[str, list[str]] = {}
+    for model in _MODELS:
+        chat.setdefault(model.provider, []).append(model.id)
+    return {"chat": chat, "image": list(IMAGE_MODELS), "audio": list(AUDIO_MODELS)}

--- a/apps/api/tests/test_flows.py
+++ b/apps/api/tests/test_flows.py
@@ -932,3 +932,11 @@ def test_whatsapp_channel_inbound_ai_takeover_and_session(authenticated_client: 
     assert reply.json()["messages"][-1]["external_message_id"] == "wa-out-human-1"
     sender.assert_awaited_once()
     assert client.patch(f"/api/conversations/{conversation_id}/mode", json={"mode": "ai"}).json()["mode"] == "ai"
+
+
+def test_available_models_lists_the_catalog(authenticated_client):
+    body = authenticated_client.get("/api/catalog/available").json()
+    assert "gpt-5.6-luna" in body["chat"]["openai"]
+    assert "claude-sonnet-5" in body["chat"]["anthropic"]
+    assert "whisper-1" in body["audio"]
+    assert "gpt-5.6-luna" in body["image"]

--- a/apps/api/tests/test_reports.py
+++ b/apps/api/tests/test_reports.py
@@ -45,7 +45,10 @@ def test_reports_aggregate_the_range(authenticated_client: TestClient, monkeypat
         row.first_reply_at = row.created_at + timedelta(seconds=60)
         db.commit()
 
-    today = date.today()
+    # UTC, not the machine's local date: the default report range groups by
+    # UTC days (tz_offset 0) and the rows above were stamped in UTC, so a
+    # local evening west of Greenwich must not push them out of the range.
+    today = now_utc().date()
     frm = (today - timedelta(days=6)).isoformat()
     report = client.get(f"/api/portal/{slug}/reports?from={frm}&to={today.isoformat()}").json()
 

--- a/apps/web/app/agents/[id]/page.tsx
+++ b/apps/web/app/agents/[id]/page.tsx
@@ -14,6 +14,7 @@ import { AgentToolsTab } from "@/components/agent-tools/agent-tools-tab";
 import { EscalationRulesEditor } from "@/components/escalation-rules";
 import { Combobox } from "@/components/combobox";
 import { PROVIDERS, modelsFor, defaultModelFor, estimateTokens, modelContextWindow, AUDIO_MODELS, IMAGE_MODELS } from "@/lib/providers";
+import { narrowModels, useAvailableModels } from "@/lib/use-available-models";
 import { TIMEZONES } from "@/lib/timezones";
 import type { Agent, AgentTool, Client, KnowledgeDocument, QAPair } from "@/types";
 
@@ -21,6 +22,7 @@ type Tab = "details" | "knowledge" | "tools" | "widget" | "playground";
 
 export default function AgentDetailPage() {
   const t = useT();
+  const available = useAvailableModels();
   const toast = useToast();
   const { id } = useParams<{ id: string }>();
   const [agent, setAgent] = useState<Agent | null>(null);
@@ -157,7 +159,7 @@ export default function AgentDetailPage() {
       </div></section>
       <section className="settings-section"><div className="settings-copy"><h3>{t("agents.detail.aiModelHeading")}</h3><p>{t("agents.detail.aiModelCopy")}</p></div><div className="settings-fields">
         <label>{t("agents.detail.timezoneLabel")}<Combobox value={timezone} onChange={setTimezone} options={TIMEZONES} placeholder={t("agents.detail.timezoneLabel")} /></label>
-        <div className="form-grid"><label>{t("agents.detail.providerLabel")}<select value={provider} onChange={(e) => { setProvider(e.target.value); if (!modelsFor(e.target.value).includes(model)) setModel(defaultModelFor(e.target.value)); }}>{PROVIDERS.map((p) => <option key={p.id} value={p.id}>{p.label}</option>)}</select></label><label>{t("agents.detail.modelLabel")}<Combobox value={model} onChange={setModel} options={modelsFor(provider)} placeholder={t("agents.detail.modelPlaceholder")} allowCustom /></label></div>
+        <div className="form-grid"><label>{t("agents.detail.providerLabel")}<select value={provider} onChange={(e) => { setProvider(e.target.value); if (!modelsFor(e.target.value).includes(model)) setModel(defaultModelFor(e.target.value)); }}>{PROVIDERS.map((p) => <option key={p.id} value={p.id}>{p.label}</option>)}</select></label><label>{t("agents.detail.modelLabel")}<Combobox value={model} onChange={setModel} options={narrowModels(modelsFor(provider), available?.chat?.[provider])} placeholder={t("agents.detail.modelPlaceholder")} allowCustom /></label></div>
         <div className="context-bar"><div style={{ width: `${contextPct}%` }} /><small><Sparkles size={12} /> {t("agents.detail.contextUsage", { count: promptTokens.toLocaleString("es"), total: contextWindow.toLocaleString("es") })}</small></div>
         <Alert type="info">{t("agents.detail.providerKeysPrefix")}<Link href="/settings">{t("agents.detail.settingsLink")}</Link>.</Alert>
         <details className="advanced-options wizard-advanced"><summary>{t("agents.detail.advancedHeading")}</summary><p className="field-help">{t("agents.detail.advancedCopy")}</p>
@@ -169,11 +171,11 @@ export default function AgentDetailPage() {
       <section className="settings-section"><div className="settings-copy"><h3>{t("agents.detail.capabilitiesHeading")}</h3><p>{t("agents.detail.capabilitiesCopy")}</p></div><div className="settings-fields">
         <div className="capability">
           <label className="capability-head"><input type="checkbox" checked={imageEnabled} onChange={(e) => setImageEnabled(e.target.checked)} /><ImageIcon size={17} /><span><strong>{t("agents.detail.imageLabel")}</strong><small>{t("agents.detail.imageHint")}</small></span></label>
-          {imageEnabled && <label className="capability-model">{t("agents.detail.modelLabel")}<Combobox value={imageModel} onChange={setImageModel} options={IMAGE_MODELS} placeholder="gpt-4.1" allowCustom /></label>}
+          {imageEnabled && <label className="capability-model">{t("agents.detail.modelLabel")}<Combobox value={imageModel} onChange={setImageModel} options={narrowModels(IMAGE_MODELS, available?.image)} placeholder="gpt-4.1" allowCustom /></label>}
         </div>
         <div className="capability">
           <label className="capability-head"><input type="checkbox" checked={audioEnabled} onChange={(e) => setAudioEnabled(e.target.checked)} /><AudioLines size={17} /><span><strong>{t("agents.detail.audioLabel")}</strong><small>{t("agents.detail.audioHint")}</small></span></label>
-          {audioEnabled && <label className="capability-model">{t("agents.detail.modelLabel")}<Combobox value={audioModel} onChange={setAudioModel} options={AUDIO_MODELS} placeholder="whisper-1" allowCustom /></label>}
+          {audioEnabled && <label className="capability-model">{t("agents.detail.modelLabel")}<Combobox value={audioModel} onChange={setAudioModel} options={narrowModels(AUDIO_MODELS, available?.audio)} placeholder="whisper-1" allowCustom /></label>}
         </div>
         <Alert type="info">{t("agents.detail.capabilitiesOpenAI")}</Alert>
       </div></section>

--- a/apps/web/app/agents/new/page.tsx
+++ b/apps/web/app/agents/new/page.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@/components/toast";
 import { api, messageFrom } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { PROVIDERS, modelsFor, modelOptionsFor, defaultModelFor, estimateTokens } from "@/lib/providers";
+import { narrowModels, useAvailableModels } from "@/lib/use-available-models";
 import { Combobox } from "@/components/combobox";
 import { TIMEZONES } from "@/lib/timezones";
 import { agentTemplates, localize } from "@/lib/agent-templates";
@@ -22,6 +23,7 @@ const STEP_KEYS = ["agents.wizard.s1", "agents.wizard.s2", "agents.wizard.s3", "
 
 export default function NewAgentPage() {
   const { t, lang } = useLanguage();
+  const available = useAvailableModels();
   const toast = useToast();
   const router = useRouter();
   const [step, setStep] = useState(0);
@@ -137,8 +139,8 @@ export default function NewAgentPage() {
         <label>{t("agents.new.providerLabel")}<select value={provider} onChange={(e) => { setProvider(e.target.value); setModel(defaultModelFor(e.target.value)); }}>{PROVIDERS.map((p) => <option key={p.id} value={p.id}>{p.label}</option>)}</select></label>
         <div className="field-block">
           <span className="field-label">{t("agents.new.modelLabel")}</span>
-          {(["fast", "balanced", "capable"] as const).map((group) => { const options = modelOptionsFor(provider).filter((item) => item.group === group); if (!options.length) return null; return <div className="model-group" key={group}><div className="model-group-head"><span className="field-label">{t(`agents.wizard.modelGroup${group === "fast" ? "Fast" : group === "balanced" ? "Balanced" : "Capable"}`)}</span><small>{t(`agents.wizard.modelNote${group === "fast" ? "Fast" : group === "balanced" ? "Balanced" : "Capable"}`)}</small></div><div className="model-recommendations">{options.map((option) => <button type="button" key={option.id} className={option.id === model ? "active" : ""} onClick={() => setModel(option.id)}><span><strong>{option.label}</strong>{option.recommended && <em>{t("agents.wizard.modelBadgeRecommended")}</em>}</span><code>{option.id}</code></button>)}</div></div>; })}
-          <details className="advanced-options wizard-advanced"><summary>{t("agents.wizard.modelShowAll")}</summary><Combobox value={model} onChange={setModel} options={modelsFor(provider)} placeholder={t("agents.new.modelPlaceholder")} allowCustom /></details>
+          {(["fast", "balanced", "capable"] as const).map((group) => { const allowed = new Set(narrowModels(modelsFor(provider), available?.chat?.[provider])); const options = modelOptionsFor(provider).filter((item) => item.group === group && allowed.has(item.id)); if (!options.length) return null; return <div className="model-group" key={group}><div className="model-group-head"><span className="field-label">{t(`agents.wizard.modelGroup${group === "fast" ? "Fast" : group === "balanced" ? "Balanced" : "Capable"}`)}</span><small>{t(`agents.wizard.modelNote${group === "fast" ? "Fast" : group === "balanced" ? "Balanced" : "Capable"}`)}</small></div><div className="model-recommendations">{options.map((option) => <button type="button" key={option.id} className={option.id === model ? "active" : ""} onClick={() => setModel(option.id)}><span><strong>{option.label}</strong>{option.recommended && <em>{t("agents.wizard.modelBadgeRecommended")}</em>}</span><code>{option.id}</code></button>)}</div></div>; })}
+          <details className="advanced-options wizard-advanced"><summary>{t("agents.wizard.modelShowAll")}</summary><Combobox value={model} onChange={setModel} options={narrowModels(modelsFor(provider), available?.chat?.[provider])} placeholder={t("agents.new.modelPlaceholder")} allowCustom /></details>
           <span className="field-help">{t("agents.wizard.modelHelp")}</span>
         </div>
         <details className="advanced-options wizard-advanced"><summary>{t("agents.detail.advancedHeading")}</summary><p className="field-help">{t("agents.detail.advancedCopy")}</p>

--- a/apps/web/lib/use-available-models.ts
+++ b/apps/web/lib/use-available-models.ts
@@ -1,0 +1,39 @@
+"use client";
+
+// Which models this workspace can actually pick, asked from the API so a
+// deployment can narrow the offer (a stock install returns the full catalog).
+// While loading or on error the static lists apply unchanged.
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+export type AvailableModels = {
+  chat: Record<string, string[]>;
+  image: string[];
+  audio: string[];
+};
+
+let cached: AvailableModels | null = null;
+
+export function useAvailableModels(): AvailableModels | null {
+  const [data, setData] = useState<AvailableModels | null>(cached);
+  useEffect(() => {
+    if (cached) return;
+    api<AvailableModels>("/catalog/available")
+      .then((payload) => {
+        cached = payload;
+        setData(payload);
+      })
+      .catch(() => {});
+  }, []);
+  return data;
+}
+
+/** Intersect a static list with the allowed ids; an unknown or empty answer
+ * keeps the full list, so the UI never ends up with nothing to offer. */
+export function narrowModels(list: readonly string[], allowed?: string[] | null): string[] {
+  if (!allowed || !allowed.length) return [...list];
+  const set = new Set(allowed);
+  const kept = list.filter((id) => set.has(id));
+  return kept.length ? kept : [...list];
+}


### PR DESCRIPTION
GET /catalog/available returns the pickable model ids per provider and capability, built from the catalog plus the audio/image lists that now also live server-side. The agent editor and creation wizard intersect their static lists with the answer; on a stock install the endpoint returns the full catalog, so behavior is unchanged. A deployment can narrow the answer to the models its managed credentials actually serve.

Also stamps the reports test range in UTC so an evening west of Greenwich cannot push rows out of it.

Suite: 109 passed; web lint and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wNXcbq9kVQVr3jYxAZ5gM