### PR TITLE
Stop the base input styles from applying to checkboxes

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -153,8 +153,13 @@ h1, h2, h3, .brand { font-family: var(--font-display); letter-spacing: -.015em; 
 .modal-head { padding: 24px 26px 19px; display: flex; align-items: flex-start; justify-content: space-between; gap: 15px; border-bottom: 1px solid #eceef3; }.modal-head h2 { margin: 0 0 5px; font-size: 20px; }.modal-head p { margin: 0; color: var(--muted); font-size: 12px; }
 .modal-form, .stack-form { padding: 23px 26px 26px; display: flex; flex-direction: column; gap: 17px; }
 .modal-form label, .stack-form label, .settings-fields label, .knowledge-context label, .playground-selectors label { display: flex; flex-direction: column; gap: 7px; color: #39415b; font-size: 12px; font-weight: 700; }
-input, textarea, select { width: 100%; color: var(--ink); border: 1px solid #dfe3eb; border-radius: 9px; background: white; outline: none; transition: .15s; }
-input, select { height: 42px; padding: 0 12px; } textarea { padding: 11px 12px; line-height: 1.55; resize: vertical; }
+/* Text-like fields only. A bare `input` selector also matches checkboxes and
+   radios, which then render as full-width 42px boxes with a border, and every
+   checkbox in the app has to undo it locally. */
+input:not([type="checkbox"]):not([type="radio"]), textarea, select { width: 100%; color: var(--ink); border: 1px solid #dfe3eb; border-radius: 9px; background: white; outline: none; transition: .15s; }
+input:not([type="checkbox"]):not([type="radio"]), select { height: 42px; padding: 0 12px; }
+input[type="checkbox"], input[type="radio"] { width: 18px; height: 18px; accent-color: #635bff; cursor: pointer; flex: 0 0 auto; }
+textarea { padding: 11px 12px; line-height: 1.55; resize: vertical; }
 input:focus, textarea:focus, select:focus, .phone-input:focus-within { border-color: #a99fff; box-shadow: 0 0 0 3px #f0eeff; }
 input::placeholder, textarea::placeholder { color: #adb3c2; font-weight: 400; }
 .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
@@ -263,7 +268,7 @@ h1, h2, h3, .brand { font-family: var(--font-display); }
 .filter-select { min-width: 240px; display: flex; align-items: center; gap: 9px; color: #687082; font-size: 13px; }
 .filter-select select { height: 44px; min-width: 190px; }
 label { color: #343b4d; font-size: 14px; font-weight: 600; }
-input, textarea, select { min-height: 43px; padding: 10px 12px; color: #202638; border: 1px solid #cfd6df; border-radius: 7px; background: white; font-size: 14px; }
+input:not([type="checkbox"]):not([type="radio"]), textarea, select { min-height: 43px; padding: 10px 12px; color: #202638; border: 1px solid #cfd6df; border-radius: 7px; background: white; font-size: 14px; }
 input:focus, textarea:focus, select:focus, .phone-input:focus-within { outline: 0; border-color: #7770ff; box-shadow: 0 0 0 3px rgba(99,91,255,.13); }
 textarea { line-height: 1.55; }
 .field-help { margin-top: 6px; color: #7d8593; font-size: 12px; font-weight: 400; }


### PR DESCRIPTION
`input, textarea, select` matches checkboxes and radios as well, so a checkbox picks up all three base rules:

```css
input, textarea, select { width: 100%; ... }
input, select          { height: 42px; padding: 0 12px; }
input, textarea, select { min-height: 43px; padding: 10px 12px; border: 1px solid #cfd6df; ... }
```

It renders as a large bordered box. Worse, inside a flex row it takes width from its siblings, so the elements next to it shift by a different amount per row depending on their content length.

## The workarounds are the evidence

Every checkbox in the app already undoes this locally:

- `.switch-row input[type="checkbox"]` overrides it with **eight** `!important` declarations
- `.capability-head input[type="checkbox"]` restates the size
- `.slider-field input[type="range"]` and `.color-input input[type="color"]` are the same shape for other input types

There is no unscoped `input[type="checkbox"]` rule, so any checkbox outside those two contexts is broken until someone notices.

## The change

The three base rules exclude `checkbox` and `radio`, and those get one shared declaration instead, using the size and accent colour `.capability-head` had already settled on.

Everything else still matches: text, email, password, date, url, file, range, colour, textarea and select.

## Verified

`next build` passes from a clean `.next`. The first attempt reported three type errors, which turned out to be stale entries in `.next/dev/types` from an earlier build, not from this change; removing the cache cleared them.

Left alone deliberately: the `!important` flags in `.switch-row` are now unnecessary, and `.capability-head`'s size rule is redundant. Removing them is a separate cleanup with its own risk, and neither is wrong today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)