### PR TITLE
Drop the !important flags from the switch-row toggle

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -969,14 +969,14 @@ textarea { line-height: 1.55; }
   gap: 18px;
 }
 .switch-row input[type="checkbox"] {
-  width: 42px !important;
-  min-width: 42px !important;
-  max-width: 42px !important;
-  height: 24px !important;
-  min-height: 24px !important;
-  max-height: 24px !important;
-  padding: 0 !important;
-  margin: 0 !important;
+  width: 42px;
+  min-width: 42px;
+  max-width: 42px;
+  height: 24px;
+  min-height: 24px;
+  max-height: 24px;
+  padding: 0;
+  margin: 0;
   display: block;
   flex: 0 0 42px;
   appearance: none;


### PR DESCRIPTION
Follow-up to #50. The eight `!important` flags on `.switch-row input[type="checkbox"]` existed to beat the base input rules, which gave a checkbox full width, a 42px height and a 43px min-height. Those rules no longer match checkboxes, so the flags have nothing to fight.

## Why it is safe without them

`.switch-row input[type="checkbox"]` is (0,2,1). Its competitors are lower:

| rule | specificity | sets |
| --- | --- | --- |
| `.switch-row input` | (0,1,1) | 39x22 |
| `input[type="checkbox"]` | (0,1,1) | 18x18 |
| base `input` rules | — | no longer match checkboxes |

It wins on specificity alone. I also checked there is no second stylesheet, no inline style on any switch-row input, and no other `!important` reaching the control. The one that remains in `.switch-row` is `flex-direction: row` on the container, which is unrelated.

The toggle keeps its 42x24.

## Left in place

`min-width`, `max-width`, `min-height` and `max-height` are redundant for the same reason. They are harmless, and taking them out is a separate change with its own way of going wrong, so this one stays limited to removing the flags.

`next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)