### PR TITLE
Style the password reveal button inside its field

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -379,8 +379,8 @@ textarea { line-height: 1.55; }
 .secret-input { position: relative; display: block; }
 .secret-input input { width: 100%; padding-right: 42px; }
 .key-input input { width: 100%; padding-right: 42px; font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace); }
-.key-input .reveal { position: absolute; top: 50%; right: 6px; transform: translateY(-50%); height: 30px; width: 30px; display: inline-flex; align-items: center; justify-content: center; padding: 0; border: none; background: none; color: #6c7483; cursor: pointer; border-radius: 6px; }
-.key-input .reveal:hover { background: #f1f2f5; color: var(--ink); }
+.key-input .reveal, .secret-input .reveal { position: absolute; top: 50%; right: 6px; transform: translateY(-50%); height: 30px; width: 30px; display: inline-flex; align-items: center; justify-content: center; padding: 0; border: none; background: none; color: #6c7483; cursor: pointer; border-radius: 6px; }
+.key-input .reveal:hover, .secret-input .reveal:hover { background: #f1f2f5; color: var(--ink); }
 .button.danger { color: white; border: 0; background: var(--red); }
 .button.danger:hover { filter: brightness(.95); }
 .key-configured { display: flex; align-items: center; justify-content: space-between; gap: 14px; flex-wrap: wrap; }


### PR DESCRIPTION
Follow-up to #53: the `.reveal` rules in `globals.css` were scoped to `.key-input`, so the toggle rendered as a bare default button below the password input. The rules now cover `.secret-input` too, which puts the eye inside the field, borderless, with only the hover tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fdwqmPZ8hA9k14vqLvL8j
