### PR TITLE
Keep the focus ring on the search box wrapper only

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -134,7 +134,10 @@ h1, h2, h3, .brand { font-family: var(--font-display); letter-spacing: -.015em; 
 
 .toolbar { margin-bottom: 20px; display: flex; align-items: center; justify-content: space-between; gap: 15px; }
 .search-box { width: min(420px, 100%); height: 42px; padding: 0 13px; display: flex; align-items: center; gap: 9px; color: #8991a7; border: 1px solid var(--line); background: white; border-radius: 10px; }
-.search-box:focus-within { color: var(--purple); border-color: #bdb5ff; box-shadow: 0 0 0 3px #eeebff; }.search-box input { width: 100%; border: 0; outline: 0; color: var(--ink); background: transparent; }
+.search-box:focus-within { color: var(--purple); border-color: #bdb5ff; box-shadow: 0 0 0 3px #eeebff; }
+/* The wrapper carries the focus ring; the inner input must not draw its own
+   (the global input:focus rule would, at the same specificity). */
+.search-box input:focus, .slug-input input:focus, .template-search input:focus, .phone-menu-search input:focus { border: 0; box-shadow: none; }.search-box input { width: 100%; border: 0; outline: 0; color: var(--ink); background: transparent; }
 .result-count { color: var(--muted); font-size: 12px; }
 .cards-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
 .client-card, .agent-card { min-height: 260px; padding: 22px; position: relative; border: 1px solid var(--line); border-radius: 15px; background: white; box-shadow: 0 3px 13px rgba(35,42,72,.025); transition: .18s ease; }


### PR DESCRIPTION
When a search box is focused, the inner input drew its own ring from the global `input:focus` rule (same specificity as the wrapper override, later in the file), so the box showed two rings, the inner one smaller than the border. The inner input now has no border and no shadow on focus; the wrapper's `:focus-within` ring is the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8ajDYEb2WBDxdss29Duf7