### PR TITLE
Show human replies live in the web chat and open a new case after resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Docker stack; run `alembic upgrade head` on local setups).
   the members of its tray instead of every portal device.
 
 ### Fixed
+- The web chat widget now shows what a person writes after taking over a
+  conversation, live, labelled with their name; it used to display only the
+  agent's replies. A message sent after the conversation was resolved opens a
+  new case, as on WhatsApp, instead of landing in the closed one.
 
 - Inbox lists (portal and agency) order by the contact's last message instead
   of the row's last write, so opening, replying to, assigning or resolving a

--- a/apps/api/app/ratelimit.py
+++ b/apps/api/app/ratelimit.py
@@ -66,6 +66,9 @@ class RateLimiter:
 # widget message endpoint is throttled because each call spends LLM tokens.
 login_rate_limit = RateLimiter(10, 60, name="login")
 widget_rate_limit = RateLimiter(30, 60, name="widget")
+# The widget polls for what people and agents write while it is open; a poll
+# spends no tokens, so it gets its own, wider budget.
+widget_poll_rate_limit = RateLimiter(120, 60, name="widget-poll")
 public_asset_rate_limit = RateLimiter(60, 60, name="public-asset")
 # The Meta webhook is authenticated by its HMAC signature; this generous limit
 # only guards against floods of unsigned traffic.

--- a/apps/api/app/routers/widget.py
+++ b/apps/api/app/routers/widget.py
@@ -1,13 +1,15 @@
 import uuid
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..database import get_db
 from ..services.conversation_state import exchanged_only
 from ..models import Agency, Agent, Client, Conversation, Message, MessageAttachment, WidgetChannel, now_utc
-from ..ratelimit import public_asset_rate_limit, widget_rate_limit
+from ..ratelimit import public_asset_rate_limit, widget_poll_rate_limit, widget_rate_limit
 from ..schemas import WidgetConfigOut, WidgetMessageIn, WidgetReply
 from ..services.attachments import (
     MAX_ATTACHMENT_BYTES,
@@ -35,9 +37,12 @@ HISTORY_LIMIT = 50
 
 def _message_out(item: Message) -> dict:
     return {
+        "id": item.id,
         "role": item.role,
         "content": item.content,
         "created_at": item.created_at,
+        "sender_type": item.sender_type,
+        "sender_name": item.sender_name,
         "attachments": [
             {"id": a.id, "kind": a.kind, "mime": a.mime, "filename": a.filename, "size_bytes": a.size_bytes}
             for a in item.attachments
@@ -59,17 +64,38 @@ def _channel(db: Session, public_id: str) -> WidgetChannel:
     return channel
 
 
+def _session_filters(channel: WidgetChannel, session_id: str):
+    return (Conversation.widget_channel_id == channel.id, Conversation.external_chat_id == f"widget:{session_id}")
+
+
 def _find_conversation(db: Session, channel: WidgetChannel, session_id: str) -> Conversation | None:
+    """The visitor's latest case. Earlier, resolved ones stay as history."""
     return db.scalar(
-        select(Conversation).where(
-            Conversation.widget_channel_id == channel.id,
-            Conversation.external_chat_id == f"widget:{session_id}",
-        )
+        select(Conversation).where(*_session_filters(channel, session_id)).order_by(Conversation.created_at.desc()).limit(1)
     )
 
 
+def _session_messages(db: Session, channel: WidgetChannel, session_id: str, *, after: datetime | None = None) -> list[Message]:
+    """What was exchanged with this visitor across all their cases, oldest
+    first. Activity lines never leave the inbox."""
+    query = (
+        select(Message)
+        .join(Conversation, Conversation.id == Message.conversation_id)
+        .options(selectinload(Message.attachments))
+        .where(*_session_filters(channel, session_id), Message.kind == "message")
+    )
+    if after is not None:
+        query = query.where(Message.created_at > after)
+    rows = db.scalars(query.order_by(Message.created_at.desc()).limit(HISTORY_LIMIT)).all()
+    return list(reversed(rows))
+
+
 def _conversation(db: Session, channel: WidgetChannel, session_id: str) -> Conversation:
+    """The open case for this visitor, or a fresh one: like WhatsApp, a
+    message after a resolution starts a new conversation."""
     conversation = _find_conversation(db, channel, session_id)
+    if conversation is not None and conversation.status == "resolved":
+        conversation = None
     if not conversation:
         conversation = Conversation(
             agency_id=channel.agency_id,
@@ -118,26 +144,50 @@ def widget_logo(public_id: str, db: Session = Depends(get_db)):
 
 @router.get("/{public_id}/history", response_model=WidgetReply, dependencies=[Depends(widget_rate_limit)])
 def widget_history(public_id: str, session_id: str, db: Session = Depends(get_db)):
-    conversation = _find_conversation(db, _channel(db, public_id), session_id)
+    channel = _channel(db, public_id)
+    conversation = _find_conversation(db, channel, session_id)
     if not conversation:
-        return {"mode": "ai", "reply": None, "messages": []}
-    messages = db.scalars(
-        select(Message)
-        .options(selectinload(Message.attachments))
-        .where(Message.conversation_id == conversation.id)
-        .order_by(Message.created_at)
-        .limit(HISTORY_LIMIT)
-    ).all()
+        return {"mode": "ai", "status": "open", "reply": None, "messages": []}
     return {
         "mode": conversation.mode,
+        "status": conversation.status,
         "reply": None,
-        "messages": [_message_out(item) for item in messages],
+        "messages": [_message_out(item) for item in _session_messages(db, channel, session_id)],
+    }
+
+
+@router.get("/{public_id}/updates", response_model=WidgetReply, dependencies=[Depends(widget_poll_rate_limit)])
+def widget_updates(
+    public_id: str,
+    session_id: str,
+    after: datetime | None = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    """What arrived since ``after``: a person's replies while they hold the
+    conversation, an agent's replies, and where the case stands. The widget
+    polls this while it is open, so a human taking over is visible live."""
+    channel = _channel(db, public_id)
+    conversation = _find_conversation(db, channel, session_id)
+    if not conversation:
+        return {"mode": "ai", "status": "open", "reply": None, "messages": []}
+    return {
+        "mode": conversation.mode,
+        "status": conversation.status,
+        "reply": None,
+        "messages": [_message_out(item) for item in _session_messages(db, channel, session_id, after=after)],
     }
 
 
 @router.get("/{public_id}/attachments/{attachment_id}", dependencies=[Depends(widget_rate_limit)])
 def widget_attachment(public_id: str, attachment_id: uuid.UUID, session_id: str, db: Session = Depends(get_db)):
-    conversation = _find_conversation(db, _channel(db, public_id), session_id)
+    channel = _channel(db, public_id)
+    # The attachment may belong to an earlier, resolved case of the same visitor.
+    conversation = db.scalar(
+        select(Conversation)
+        .join(Message, Message.conversation_id == Conversation.id)
+        .join(MessageAttachment, MessageAttachment.message_id == Message.id)
+        .where(*_session_filters(channel, session_id), MessageAttachment.id == attachment_id)
+    )
     if not conversation:
         raise HTTPException(status_code=404, detail="Attachment not found")
     return attachment_response(conversation_attachment(db, conversation, attachment_id))
@@ -195,9 +245,9 @@ async def widget_message(public_id: str, payload: WidgetMessageIn, db: Session =
 
     if conversation.mode == "human":
         await notify_needs_human(db, conversation, content)
-        return {"mode": "human", "reply": None, "messages": []}
+        return {"mode": "human", "status": conversation.status, "reply": None, "messages": []}
     reply = await _widget_ai_reply(db, agent, conversation, content)
-    return {"mode": "ai", "reply": reply, "reply_at": now_utc() if reply else None, "messages": []}
+    return {"mode": "ai", "status": conversation.status, "reply": reply, "reply_at": now_utc() if reply else None, "messages": []}
 
 
 @router.post("/{public_id}/media", response_model=WidgetReply, dependencies=[Depends(widget_rate_limit)])
@@ -262,11 +312,5 @@ async def widget_media(
         await notify_needs_human(db, conversation, display_content or llm_content)
     reply = None if mode == "human" else await _widget_ai_reply(db, agent, conversation, llm_content)
     # Return the refreshed history so the client can render the new attachment.
-    history = db.scalars(
-        select(Message)
-        .options(selectinload(Message.attachments))
-        .where(Message.conversation_id == conversation.id)
-        .order_by(Message.created_at)
-        .limit(HISTORY_LIMIT)
-    ).all()
-    return {"mode": mode, "reply": reply, "messages": [_message_out(item) for item in history]}
+    history = _session_messages(db, channel, session_id)
+    return {"mode": mode, "status": conversation.status, "reply": reply, "messages": [_message_out(item) for item in history]}

--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -746,10 +746,14 @@ class WidgetMessageIn(BaseModel):
 
 
 class WidgetMessageOut(BaseModel):
+    id: uuid.UUID | None = None
     role: str
     content: str
     created_at: datetime | None = None
     attachments: list[AttachmentOut] = []
+    # "ai", "human" or "visitor": lets the widget label a person's reply.
+    sender_type: str | None = None
+    sender_name: str | None = None
 
 
 class WidgetReply(BaseModel):
@@ -757,6 +761,9 @@ class WidgetReply(BaseModel):
     reply: str | None = None
     reply_at: datetime | None = None
     messages: list[WidgetMessageOut] = []
+    # Where the latest case for this visitor stands; resolved means the next
+    # message opens a new one.
+    status: str = "open"
 
 
 class WhatsAppInbound(BaseModel):

--- a/apps/api/tests/test_flows.py
+++ b/apps/api/tests/test_flows.py
@@ -283,6 +283,31 @@ def test_widget_public_chat_and_gating(authenticated_client: TestClient, monkeyp
     assert inbox_row["unread"] is False
     assert inbox_row["unread_count"] == 0
 
+    # A person's reply reaches the widget through the updates poll, labelled.
+    history = client.get(f"/api/widget/{public_id}/history?session_id=s1").json()
+    assert history["mode"] == "human" and history["status"] == "open"
+    last_seen = history["messages"][-1]["created_at"]
+    assert client.post(f"/api/conversations/{conversation_id}/reply", json={"content": "Soy Ana, te ayudo"}).status_code == 200
+    updates = client.get(f"/api/widget/{public_id}/updates?session_id=s1&after={last_seen}").json()
+    assert [(m["role"], m["sender_type"], m["content"]) for m in updates["messages"]] == [("assistant", "human", "Soy Ana, te ayudo")]
+    assert updates["messages"][0]["id"] and updates["messages"][0]["sender_name"]
+    # Nothing new since that reply.
+    assert client.get(f"/api/widget/{public_id}/updates?session_id=s1&after={updates['messages'][0]['created_at']}").json()["messages"] == []
+
+    # Resolving closes the case: the visitor's next message opens a new one,
+    # while the widget keeps showing the whole exchange.
+    assert client.patch(f"/api/conversations/{conversation_id}/status", json={"status": "resolved"}).status_code == 200
+    assert client.get(f"/api/widget/{public_id}/updates?session_id=s1").json()["status"] == "resolved"
+    client.post(f"/api/widget/{public_id}/messages", json={"session_id": "s1", "content": "one more thing"})
+    rows = client.get("/api/conversations/inbox").json()
+    assert len(rows) == 2 and rows[0]["id"] != conversation_id
+    assert client.get(f"/api/conversations/{rows[0]['id']}").json()["status"] == "open"
+    history = client.get(f"/api/widget/{public_id}/history?session_id=s1").json()
+    assert history["status"] == "open"
+    # The new case starts in AI mode again, so the agent answers it.
+    assert [m["content"] for m in history["messages"]][-3:] == ["Soy Ana, te ayudo", "one more thing", "Sure, happy to help!"]
+    assert all(m["role"] in ("user", "assistant") for m in history["messages"])  # no activity lines
+
 
 def test_inbox_pagination_and_search(authenticated_client: TestClient):
     client = authenticated_client

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1627,3 +1627,5 @@ p .msg-time, .bubble .msg-time { float: none; position: absolute; right: 11px; b
 /* Timestamp inside widget chat bubbles */
 .widget-bubble:has(> .msg-time) { position: relative; padding-right: 48px; }
 .widget-bubble .msg-time { position: absolute; right: 9px; bottom: 6px; font-size: var(--text-xs); line-height: 1; color: inherit; opacity: .5; font-variant-numeric: tabular-nums; }
+
+.widget-sender { display: block; margin: 0 0 3px 6px; color: #68718a; font-size: 11px; font-weight: 600; }

--- a/apps/web/app/widget/[publicId]/page.tsx
+++ b/apps/web/app/widget/[publicId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import { Download, LoaderCircle, Send, X } from "lucide-react";
 import { api, apiUrl, messageFrom } from "@/lib/api";
@@ -12,8 +12,26 @@ import { useLanguage, useT } from "@/lib/i18n";
 import type { Attachment } from "@/types";
 
 type Config = { title: string; greeting: string; color: string; position: string; agency_name: string; logo_url: string | null };
-type Msg = { role: "user" | "assistant"; content: string; created_at?: string | null; attachments?: Attachment[] };
-type Reply = { mode: string; reply: string | null; reply_at?: string | null; messages: Msg[] };
+type Msg = { id?: string; role: "user" | "assistant"; content: string; created_at?: string | null; attachments?: Attachment[]; sender_type?: string | null; sender_name?: string | null };
+type Reply = { mode: string; status?: string; reply: string | null; reply_at?: string | null; messages: Msg[] };
+
+// Server messages carry ids; the ones we append while sending do not. Merging
+// drops the optimistic copy once its server twin arrives and never repeats
+// a message the poll has already delivered.
+function mergeMessages(current: Msg[], incoming: Msg[]): Msg[] {
+  if (!incoming.length) return current;
+  const known = new Set(current.map((m) => m.id).filter(Boolean));
+  const fresh = incoming.filter((m) => !m.id || !known.has(m.id));
+  if (!fresh.length) return current;
+  const kept = current.filter((m) => m.id || !fresh.some((f) => f.role === m.role && f.content === m.content));
+  return [...kept, ...fresh];
+}
+
+function latestStamp(messages: Msg[]): string | null {
+  let last: string | null = null;
+  for (const m of messages) if (m.id && m.created_at && (!last || m.created_at > last)) last = m.created_at;
+  return last;
+}
 
 // Tell the host loader (widget.js) to show a greeting teaser or an unread dot.
 function notifyHost(action: string, text?: string) {
@@ -31,6 +49,7 @@ export default function WidgetPage() {
   const [error, setError] = useState("");
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const openRef = useRef(false);
+  const lastAtRef = useRef<string | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -66,8 +85,35 @@ export default function WidgetPage() {
 
   useEffect(() => {
     if (!session) return;
-    api<Reply>(`/widget/${publicId}/history?session_id=${encodeURIComponent(session)}`).then((data) => setMessages(data.messages)).catch(() => {});
+    api<Reply>(`/widget/${publicId}/history?session_id=${encodeURIComponent(session)}`).then((data) => {
+      lastAtRef.current = latestStamp(data.messages);
+      setMessages(data.messages);
+    }).catch(() => {});
   }, [session, publicId]);
+
+  // Pull what arrived since the last message we know of: a person's replies
+  // once they took over, or an agent's. Every few seconds while the panel is
+  // open, far less often while it is closed (enough to raise the unread dot).
+  const refresh = useCallback(async () => {
+    if (!session) return;
+    const after = lastAtRef.current ? `&after=${encodeURIComponent(lastAtRef.current)}` : "";
+    const data = await api<Reply>(`/widget/${publicId}/updates?session_id=${encodeURIComponent(session)}${after}`);
+    if (!data.messages.length) return;
+    const newest = latestStamp(data.messages);
+    if (newest && (!lastAtRef.current || newest > lastAtRef.current)) lastAtRef.current = newest;
+    setMessages((current) => mergeMessages(current, data.messages));
+    if (!openRef.current && data.messages.some((m) => m.role !== "user")) notifyHost("unread");
+  }, [session, publicId]);
+  useEffect(() => {
+    if (!session) return;
+    let tick = 0;
+    const id = window.setInterval(() => {
+      tick += 1;
+      if (document.hidden) return;
+      if (openRef.current || tick % 5 === 0) refresh().catch(() => {});
+    }, 3000);
+    return () => window.clearInterval(id);
+  }, [session, refresh]);
 
   useEffect(() => { endRef.current?.scrollIntoView({ behavior: "smooth" }); }, [messages.length, busy]);
 
@@ -105,11 +151,10 @@ export default function WidgetPage() {
     setBusy(true); setError("");
     setMessages((current) => [...current, { role: "user", content, created_at: new Date().toISOString() }]);
     try {
-      const data = await api<Reply>(`/widget/${publicId}/messages`, { method: "POST", body: JSON.stringify({ session_id: session, content }) });
-      if (data.reply) {
-        setMessages((current) => [...current, { role: "assistant", content: data.reply as string, created_at: data.reply_at ?? new Date().toISOString() }]);
-        if (!openRef.current) notifyHost("unread");
-      }
+      await api<Reply>(`/widget/${publicId}/messages`, { method: "POST", body: JSON.stringify({ session_id: session, content }) });
+      // The reply, when there is one, comes back through the same channel as
+      // everything else, with its id, so nothing shows twice.
+      await refresh();
     } catch (err) { setError(messageFrom(err)); } finally { setBusy(false); inputRef.current?.focus(); }
   }
 
@@ -124,7 +169,7 @@ export default function WidgetPage() {
       if (caption) data.append("caption", caption);
       const result = await api<Reply>(`/widget/${publicId}/media`, { method: "POST", body: data });
       if (inputRef.current) inputRef.current.value = "";
-      if (result.messages.length) setMessages(result.messages);
+      if (result.messages.length) { lastAtRef.current = latestStamp(result.messages); setMessages(result.messages); }
     } catch (err) { setError(messageFrom(err)); } finally { setBusy(false); inputRef.current?.focus(); }
   }
 
@@ -147,7 +192,7 @@ export default function WidgetPage() {
       </header>
       <div className="widget-messages">
         {showGreeting && <div className="widget-msg assistant"><div className="widget-bubble"><RichText text={config.greeting} /></div></div>}
-        {messages.map((message, index) => <div key={index} className={`widget-msg ${message.role}`}><div className="widget-msg-body"><MessageAttachments attachments={message.attachments} urlFor={attachmentUrl} gallery={gallery} stamp={message.created_at ? formatTime(message.created_at, lang) : undefined} />{message.content && <div className="widget-bubble"><RichText text={message.content} />{message.created_at && <time className="msg-time">{formatTime(message.created_at, lang)}</time>}</div>}</div></div>)}
+        {messages.map((message, index) => <div key={index} className={`widget-msg ${message.role}`}><div className="widget-msg-body"><MessageAttachments attachments={message.attachments} urlFor={attachmentUrl} gallery={gallery} stamp={message.created_at ? formatTime(message.created_at, lang) : undefined} />{message.sender_type === "human" && message.sender_name && <small className="widget-sender">{message.sender_name}</small>}{message.content && <div className="widget-bubble"><RichText text={message.content} />{message.created_at && <time className="msg-time">{formatTime(message.created_at, lang)}</time>}</div>}</div></div>)}
         {busy && <div className="widget-msg assistant"><div className="widget-bubble widget-typing"><i /><i /><i /></div></div>}
         <div ref={endRef} />
       </div>

--- a/docs/en/web-widget.md
+++ b/docs/en/web-widget.md
@@ -36,6 +36,8 @@ When a visitor sends a message, the widget calls the public endpoint `POST /api/
 
 These public endpoints are rate-limited per client IP (30 message requests per minute) because each call spends LLM tokens. Callers over the limit get `429 Too Many Requests` with a `Retry-After` header. The limiter reads the client IP from `X-Forwarded-For` set by the gateway. See [Configuration](configuration.md) for the `RATE_LIMIT_ENABLED` toggle.
 
+While open, the widget also polls `GET /api/widget/<publicId>/updates` every few seconds (its own, wider limit of 120 per minute), so replies written by a person who took over the conversation appear live, labelled with their name. Resolving a conversation closes the case: the visitor's next message opens a new one, and the widget keeps showing the whole exchange.
+
 ## Widget conversations in the inbox
 
 Every widget chat becomes a conversation on the `widget` channel, so it shows up in the [Inbox](inbox.md) alongside WhatsApp and playground threads. You can filter by the widget channel, read the full transcript, and switch a conversation to **human** mode — which pauses the AI so an operator can reply directly from the portal.

--- a/docs/es/web-widget.md
+++ b/docs/es/web-widget.md
@@ -36,6 +36,8 @@ Cuando un visitante envía un mensaje, el widget llama al endpoint público `POS
 
 Estos endpoints públicos tienen límite de peticiones por IP de cliente (30 peticiones de mensaje por minuto) porque cada llamada consume tokens del LLM. Quien supere el límite recibe `429 Too Many Requests` con una cabecera `Retry-After`. El limitador lee la IP del cliente desde `X-Forwarded-For` que establece el gateway. Consulta [Configuración](configuration.md) para el interruptor `RATE_LIMIT_ENABLED`.
 
+Mientras está abierto, el widget también consulta `GET /api/widget/<publicId>/updates` cada pocos segundos (con su propio límite, más amplio, de 120 por minuto), así que las respuestas que escribe una persona que tomó el control aparecen en vivo, con su nombre. Resolver una conversación cierra el caso: el siguiente mensaje del visitante abre uno nuevo, y el widget sigue mostrando todo el intercambio.
+
 ## Conversaciones del widget en el inbox
 
 Cada chat del widget se convierte en una conversación del canal `widget`, así que aparece en el [Inbox](inbox.md) junto a los hilos de WhatsApp y del playground. Puedes filtrar por el canal del widget, leer la transcripción completa y cambiar una conversación a modo **humano**, lo que pausa la IA para que un operador responda directamente desde el portal.


### PR DESCRIPTION
Two reported widget problems, one cause: the widget loaded its history once and only appended the agent reply returned by each send.

- **Human replies never reached the visitor.** The widget now polls `GET /api/widget/{public_id}/updates?after=` every few seconds while open (and rarely while closed, to raise the unread dot), under its own 120/min rate limit since a poll spends no tokens. Messages merge by id; a person's reply shows their name.
- **A message after resolving landed in the closed case.** It now opens a new conversation, as WhatsApp inbound does. History and updates span every case of the visitor's session and exclude activity lines.

The test covers the human reply through the poll, the empty poll afterwards, and the new case after resolving. API suite: 111 passed. Web: tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8ajDYEb2WBDxdss29Duf7