### PR TITLE
Keep a closed case out of the web chat updates poll

### DIFF
--- a/apps/api/app/routers/widget.py
+++ b/apps/api/app/routers/widget.py
@@ -232,7 +232,10 @@ def widget_updates(
     if not conversation:
         return {"mode": "ai", "status": "open", "reply": None, "messages": []}
     # A resolved latest case is reported as such, with nothing new: the widget
-    # then starts a fresh chat and moves it to history.
+    # then starts a fresh chat and moves it to history. Its messages never
+    # come back through here, or a fresh chat would fill up with them again.
+    if conversation.status == "resolved":
+        return {"mode": conversation.mode, "status": "resolved", "conversation_id": conversation.id, "reply": None, "messages": []}
     return {
         "mode": conversation.mode,
         "status": conversation.status,

--- a/apps/api/tests/test_flows.py
+++ b/apps/api/tests/test_flows.py
@@ -299,7 +299,8 @@ def test_widget_public_chat_and_gating(authenticated_client: TestClient, monkeyp
     # Resolving closes the case: the visitor's next message opens a new one,
     # while the widget keeps showing the whole exchange.
     assert client.patch(f"/api/conversations/{conversation_id}/status", json={"status": "resolved"}).status_code == 200
-    assert client.get(f"/api/widget/{public_id}/updates?session_id=s1").json()["status"] == "resolved"
+    closed = client.get(f"/api/widget/{public_id}/updates?session_id=s1").json()
+    assert closed["status"] == "resolved" and closed["messages"] == []  # never refills a fresh chat
     # Right after closing, the widget starts blank and the thread is history.
     fresh = client.get(f"/api/widget/{public_id}/history?session_id=s1").json()
     assert fresh["messages"] == [] and fresh["conversation_id"] is None


### PR DESCRIPTION
After a case was resolved, the widget started blank and then refilled with the closed thread: the updates poll read the latest case regardless of status and, with no `after` cursor on a fresh chat, returned everything. A resolved latest case now reports its status with no messages. Test covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8ajDYEb2WBDxdss29Duf7