### PR TITLE
Keep reactions and quoted replies to WhatsApp, export past web chats too

### DIFF
--- a/apps/web/app/portal/[slug]/page.tsx
+++ b/apps/web/app/portal/[slug]/page.tsx
@@ -286,6 +286,8 @@ function PortalInbox({ slug, portal, session, logout }: { slug: string; portal: 
   }
   const memberLabel = (member: Member) => (member.id === session.user_id ? t("portal.inbox.assignment.me", { name: member.name }) : member.name);
   const isResolved = selected?.status === "resolved";
+  // Reactions and quoted replies travel over WhatsApp only; the web chat has no way to show them.
+  const gesturesAvailable = selected?.channel === "whatsapp" || selected?.channel === "whatsapp_cloud";
   const windowClosed = Boolean(selected) && selected?.channel === "whatsapp_cloud" && selected?.reply_window_open === false;
   const canReply = Boolean(selected) && selected?.mode === "human" && !isResolved && !windowClosed;
   const activityText = (message: Message) => {
@@ -376,7 +378,7 @@ function PortalInbox({ slug, portal, session, logout }: { slug: string; portal: 
               const mine = message.role === "assistant";
               return <article key={message.id} className={`${message.role}${mine ? " mine" : ""}${mine && message.sender_type === "ai" ? " ai" : ""}${grouped ? " grouped" : ""}`}>
                 {!grouped && <small>{message.sender_name || (message.role === "assistant" ? t("portal.inbox.conversation.agent") : t("portal.inbox.conversation.visitor"))}</small>}
-                {canReply && <span className="bubble-actions">
+                {canReply && gesturesAvailable && <span className="bubble-actions">
                   {message.role === "user" && <button type="button" title={t("portal.inbox.conversation.react")} aria-label={t("portal.inbox.conversation.react")} onClick={() => setReactingTo(reactingTo === message.id ? null : message.id)}><SmilePlus size={14} /></button>}
                   <button type="button" title={t("portal.inbox.conversation.reply")} aria-label={t("portal.inbox.conversation.reply")} onClick={() => { setQuoting(message); replyInputRef.current?.focus(); }}><Reply size={14} /></button>
                 </span>}

--- a/apps/web/app/widget/[publicId]/page.tsx
+++ b/apps/web/app/widget/[publicId]/page.tsx
@@ -182,11 +182,12 @@ export default function WidgetPage() {
 
   function close() { window.parent?.postMessage({ type: "ol-widget", action: "close" }, "*"); }
 
-  function exportChat() {
+  // Exports the chat on screen: the live one with its greeting, or a past one.
+  function exportChat(list: Msg[] = messages, withGreeting = true) {
     if (!config) return;
-    const transcript: typeof messages = config.greeting
-      ? [{ role: "assistant", content: config.greeting }, ...messages]
-      : messages;
+    const transcript: typeof messages = withGreeting && config.greeting
+      ? [{ role: "assistant", content: config.greeting }, ...list]
+      : list;
     const text = chatToText(transcript, { title: config.title, agentLabel: config.title, visitorLabel: t("inbox.senderVisitor") });
     downloadText(text, config.title);
   }
@@ -252,7 +253,7 @@ export default function WidgetPage() {
             <button type="button" className="widget-head-btn" onClick={() => setView(view === "past" ? "list" : "chat")} aria-label={t("chat.backToChat")}><ArrowLeft size={18} /></button>
             <div><strong>{view === "past" && past ? t("chat.chatFrom", { date: dateOf(past.item.created_at) }) : t("chat.previousChats")}</strong><small>{config.title}</small></div>
           </div>
-          <div className="widget-head-actions"><button type="button" className="widget-head-btn" onClick={close} aria-label="Close"><X size={18} /></button></div>
+          <div className="widget-head-actions">{view === "past" && past && past.messages.length > 0 && <button type="button" className="widget-head-btn" onClick={() => exportChat(past.messages, false)} title={t("chat.exportChat")} aria-label={t("chat.exportChat")}><Download size={17} /></button>}<button type="button" className="widget-head-btn" onClick={close} aria-label="Close"><X size={18} /></button></div>
         </header>
         {view === "list"
           ? <div className="widget-case-list">
@@ -273,7 +274,7 @@ export default function WidgetPage() {
         </div>
         <div className="widget-head-actions">
           {previous.length > 0 && <button type="button" className="widget-head-btn" onClick={() => setView("list")} title={t("chat.previousChats")} aria-label={t("chat.previousChats")}><History size={17} /></button>}
-          {messages.length > 0 && <button type="button" className="widget-head-btn" onClick={exportChat} title={t("chat.exportChat")} aria-label={t("chat.exportChat")}><Download size={17} /></button>}
+          {messages.length > 0 && <button type="button" className="widget-head-btn" onClick={() => exportChat()} title={t("chat.exportChat")} aria-label={t("chat.exportChat")}><Download size={17} /></button>}
           <button type="button" className="widget-head-btn" onClick={close} aria-label="Close"><X size={18} /></button>
         </div>
       </header>


### PR DESCRIPTION
- The portal showed the react and quote gestures on web chat messages; both are WhatsApp features (the widget cannot display them), so they now appear only on WhatsApp conversations.
- The widget's export button also works from a past chat opened in the history view. On a fresh chat there is nothing to export yet, so the button appears once messages exist, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8ajDYEb2WBDxdss29Duf7