### PR TITLE
Release social accounts on disconnect and name their senders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Upgrading: this release adds database migrations (applied automatically by the
 Docker stack; run `alembic upgrade head` on local setups).
 
 ### Added
+- Instagram and Messenger contacts get the sender's **name**. Webhooks only
+  carry the sender id, so the first message from an unnamed contact looks the
+  profile up on the provider (name and surname on Messenger, name and handle
+  on Instagram) and titles the conversation with it. A failed lookup leaves
+  the message untouched and the contact is named on a later message.
 - Contacts can be **blocked** from the portal. Their messages are still
   stored but the agent does not answer them (no tokens spent), nothing rings,
   and their conversations leave the inboxes until they are unblocked; the
@@ -100,6 +105,11 @@ Docker stack; run `alembic upgrade head` on local setups).
   the members of its tray instead of every portal device.
 
 ### Fixed
+- Disconnecting an Instagram or Messenger channel now **releases the
+  account**: it can be connected under another client afterwards. The old
+  row keeps its conversations. Ownership follows the credentials, so an
+  account that is still connected elsewhere is still refused (migration
+  0037 narrows the unique index to rows holding a token).
 - Switching a client off now stops its agents on WhatsApp and closes its
   portal, as the setting always claimed. It used to hide the web chat only.
 - Removing a person from a client's portal access now asks first, in a

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -757,7 +757,7 @@ class SocialChannel(Base):
     __table_args__ = (
         UniqueConstraint("client_id", "provider", name="uq_social_channels_client_provider"),
         Index("uq_social_channels_account", "provider", "external_account_id", unique=True,
-              postgresql_where=text("external_account_id <> ''")),
+              postgresql_where=text("external_account_id <> '' AND encrypted_access_token IS NOT NULL")),
     )
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=new_uuid)
     agency_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("agencies.id", ondelete="CASCADE"), index=True)

--- a/apps/api/app/services/social_connections.py
+++ b/apps/api/app/services/social_connections.py
@@ -126,7 +126,10 @@ async def connect_account(db: Session, user: User, client_id, agent_id, provider
     owned_client(db, user, client_id, agent_id)
     account_id = graph.object_id(account["id"])
     app_id = graph.object_id(config.app_id)
-    collision = db.scalar(select(SocialChannel.id).where(SocialChannel.provider == provider, SocialChannel.external_account_id == account_id, SocialChannel.client_id != client_id))
+    # A disconnected channel keeps its row for history but holds no credentials,
+    # so the account is free to be connected under another client.
+    collision = db.scalar(select(SocialChannel.id).where(SocialChannel.provider == provider, SocialChannel.external_account_id == account_id,
+        SocialChannel.client_id != client_id, SocialChannel.encrypted_access_token.is_not(None)))
     if collision:
         raise HTTPException(409, "This account is already connected to another client")
     channel = db.scalar(select(SocialChannel).where(SocialChannel.client_id == client_id, SocialChannel.agency_id == user.agency_id, SocialChannel.provider == provider).with_for_update())

--- a/apps/api/app/services/social_graph.py
+++ b/apps/api/app/services/social_graph.py
@@ -110,6 +110,19 @@ async def request(provider: str, method: str, path: str, token: str, **kwargs) -
     return await _http(method, graph_url(provider, path), token=token, **kwargs)
 
 
+async def sender_profile(provider: str, token: str, secret: str, user_id: str) -> dict:
+    """Name and handle of a person who wrote to the account. Webhooks carry
+    only the sender id; the profile is a separate read on the same token."""
+    fields = "name,username" if provider == "instagram" else "first_name,last_name,name"
+    data = await request(provider, "GET", object_id(user_id), token,
+                         params={"fields": fields, "appsecret_proof": _proof(token, secret)})
+    name = str(data.get("name") or "").strip()
+    if not name:
+        name = " ".join(str(part).strip() for part in (data.get("first_name"), data.get("last_name")) if part)
+    username = str(data.get("username") or "").strip()
+    return {"name": name[:180], "username": username[:180] or None}
+
+
 def _proof(token: str, secret: str) -> str:
     return hmac.new(secret.encode(), token.encode(), hashlib.sha256).hexdigest()
 

--- a/apps/api/app/services/social_inbound.py
+++ b/apps/api/app/services/social_inbound.py
@@ -10,7 +10,9 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, aliased
 
-from ..models import Conversation, Message, SocialChannel, SocialOutbox, SocialWebhookEvent, new_uuid, now_utc
+from ..models import ContactIdentity, Conversation, Message, SocialChannel, SocialOutbox, SocialWebhookEvent, new_uuid, now_utc
+from ..security import decrypt_secret
+from . import social_graph
 from .attachments import store_attachment
 from .conversation_state import set_mode
 from .social_media import fetch_inbound_media
@@ -76,6 +78,34 @@ def enqueue_webhook(db: Session, provider: str, payload: dict, channel: SocialCh
 def _conversation(db: Session, channel: SocialChannel, person: str) -> Conversation | None:
     return db.scalar(select(Conversation).where(Conversation.social_channel_id == channel.id,
         Conversation.external_chat_id == person).order_by(Conversation.created_at.desc()).limit(1))
+
+
+async def _name_contact(db: Session, channel: SocialChannel, person: str, sender: dict) -> None:
+    """Give the sender's contact a name the first time it is needed.
+    Webhooks only carry the sender id, so an unnamed contact is looked up on
+    the provider once; a failed lookup leaves the message untouched."""
+    from .contacts import rename_conversations, resolve_contact
+    identity = db.scalar(select(ContactIdentity).where(
+        ContactIdentity.client_id == channel.client_id, ContactIdentity.provider == channel.provider,
+        ContactIdentity.external_account_id == channel.external_account_id, ContactIdentity.external_user_id == person))
+    if identity and identity.contact.name.strip():
+        return
+    name = str(sender.get("name") or "").strip()
+    username = str(sender.get("username") or "").strip() or None
+    if not name and channel.encrypted_access_token and channel.encrypted_app_secret:
+        try:
+            profile = await social_graph.sender_profile(channel.provider, decrypt_secret(channel.encrypted_access_token),
+                                                        decrypt_secret(channel.encrypted_app_secret), person)
+            name = profile.get("name") or ""
+            username = profile.get("username") or username
+        except Exception as exc:
+            logger.info("Sender profile unavailable on %s: %s", channel.provider, type(exc).__name__)
+    name = name or username or ""
+    if not name:
+        return
+    contact = resolve_contact(db, channel.client_id, provider=channel.provider, external_account_id=channel.external_account_id,
+                              external_user_id=person, name=name, username=username)
+    rename_conversations(db, contact)
 
 
 def _message(db: Session, channel: SocialChannel, mid: str) -> Message | None:
@@ -251,6 +281,7 @@ async def process_event(db: Session, channel: SocialChannel, event: dict) -> Non
         conversation.updated_at = now_utc()
         db.commit()
         return
+    await _name_contact(db, channel, person, event.get("sender") or {})
     inbound = InboundMessage(external_message_id=mid, external_chat_id=person,
         text=text, media_kind=kind if kind in ("image", "audio", "video", "file") else None,
         sender_name=(event.get("sender") or {}).get("name") or (event.get("sender") or {}).get("username"),

--- a/apps/api/migrations/versions/0037_release_social_accounts.py
+++ b/apps/api/migrations/versions/0037_release_social_accounts.py
@@ -1,0 +1,31 @@
+"""A disconnected social channel no longer reserves its account.
+
+The unique index on ``social_channels`` (provider, external_account_id) used
+to cover every row with an account id, so an account that had been connected
+once could never be connected under another client, even after it was
+disconnected. Ownership now follows the credentials: only rows that still
+hold an access token take part in the index. Disconnecting clears the token,
+which releases the account while the row keeps its conversation history.
+
+Revision ID: 0037_release_social_accounts
+Revises: 0036_archive_and_agent_tombstone
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0037_release_social_accounts"
+down_revision = "0036_archive_and_agent_tombstone"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("uq_social_channels_account", table_name="social_channels")
+    op.create_index("uq_social_channels_account", "social_channels", ["provider", "external_account_id"], unique=True,
+                    postgresql_where=sa.text("external_account_id <> '' AND encrypted_access_token IS NOT NULL"))
+
+
+def downgrade() -> None:
+    op.drop_index("uq_social_channels_account", table_name="social_channels")
+    op.create_index("uq_social_channels_account", "social_channels", ["provider", "external_account_id"], unique=True,
+                    postgresql_where=sa.text("external_account_id <> ''"))

--- a/apps/api/tests/test_social_connections.py
+++ b/apps/api/tests/test_social_connections.py
@@ -78,6 +78,23 @@ def test_account_rebind_and_cross_client_assignment_are_rejected(authenticated_c
     assert manual(client, first, other_agent).status_code == 400
 
 
+def test_disconnecting_releases_the_account_for_another_client(authenticated_client):
+    client = authenticated_client
+    first, agent = resources(client)
+    second, other_agent = resources(client)
+    assert manual(client, first, agent).status_code == 200
+    assert manual(client, second, other_agent).status_code == 409
+    assert client.post(f"/api/social/instagram/channels/{first['id']}/disconnect").status_code == 200
+    moved = manual(client, second, other_agent)
+    assert moved.status_code == 200, moved.text
+    # The first client keeps its row for history, but the account now belongs to the second.
+    assert manual(client, first, agent).status_code == 409
+    with TestingSession() as db:
+        rows = db.scalars(select(SocialChannel).where(SocialChannel.external_account_id == "111")).all()
+        assert {str(row.client_id) for row in rows} == {first["id"], second["id"]}
+        assert sum(1 for row in rows if row.encrypted_access_token) == 1
+
+
 def test_another_agency_cannot_read_or_change_channel(authenticated_client, monkeypatch):
     client = authenticated_client
     customer, agent = resources(client)

--- a/apps/api/tests/test_social_runtime.py
+++ b/apps/api/tests/test_social_runtime.py
@@ -40,6 +40,7 @@ def isolated_providers(monkeypatch):
     monkeypatch.setattr(notifications, "notify_needs_human", AsyncMock(return_value=0))
     monkeypatch.setattr(escalation, "notify_needs_human", notifications.notify_needs_human)
     monkeypatch.setattr(social_inbound, "reply_delay_seconds", lambda agent: 0)
+    monkeypatch.setattr(social_graph, "sender_profile", AsyncMock(return_value={"name": "", "username": None}))
 
 
 def resources(client, *, provider="instagram", account="111", human_agent=True):
@@ -158,6 +159,45 @@ def test_social_digit_ids_are_account_scoped_and_never_phone_numbers(authenticat
         assert db.get(Contact, b.contact_id).phone is None
         identities = db.scalars(select(ContactIdentity).where(ContactIdentity.external_user_id == PERSON)).all()
         assert {(i.provider, i.external_account_id) for i in identities} == {("instagram", "111"), ("instagram", "222")}
+
+
+def test_sender_profile_names_the_contact_once_and_titles_the_case(authenticated_client, monkeypatch):
+    resource = resources(authenticated_client, provider="messenger", account="222")
+    lookup = AsyncMock(return_value={"name": "Ana Perez", "username": None})
+    monkeypatch.setattr(social_graph, "sender_profile", lookup)
+    with TestingSession() as db:
+        first = inbound(db, resource, mid="named-1")
+        assert first.title == "Ana Perez"
+        contact = db.get(Contact, first.contact_id)
+        assert contact.name == "Ana Perez" and contact.phone is None
+        second = inbound(db, resource, mid="named-2")
+        assert second.id == first.id
+    lookup.assert_awaited_once()
+    assert lookup.await_args.args[0] == "messenger" and lookup.await_args.args[3] == PERSON
+
+
+def test_instagram_handle_names_the_contact_when_no_name_is_shared(authenticated_client, monkeypatch):
+    resource = resources(authenticated_client)
+    monkeypatch.setattr(social_graph, "sender_profile", AsyncMock(return_value={"name": "", "username": "ana.shop"}))
+    with TestingSession() as db:
+        conversation = inbound(db, resource, mid="handle-1")
+        assert conversation.title == "ana.shop"
+        identity = db.scalar(select(ContactIdentity).where(ContactIdentity.contact_id == conversation.contact_id))
+        assert identity.username == "ana.shop"
+
+
+def test_unnamed_contact_is_named_on_a_later_message_and_lookup_failures_never_block(authenticated_client, monkeypatch):
+    resource = resources(authenticated_client)
+    monkeypatch.setattr(social_graph, "sender_profile", AsyncMock(side_effect=HTTPException(502, "Unreachable")))
+    with TestingSession() as db:
+        first = inbound(db, resource, mid="late-1")
+        assert first.title == "Contact"
+        assert db.scalar(select(func.count()).select_from(Message).where(Message.conversation_id == first.id)) >= 1
+    monkeypatch.setattr(social_graph, "sender_profile", AsyncMock(return_value={"name": "Ana Perez", "username": "ana"}))
+    with TestingSession() as db:
+        again = inbound(db, resource, mid="late-2")
+        assert again.id == first.id and again.title == "Ana Perez"
+        assert db.get(Contact, again.contact_id).name == "Ana Perez"
 
 
 def test_contact_merge_preserves_both_phone_aliases_and_social_identity(authenticated_client):


### PR DESCRIPTION
## What

- **Disconnect releases the account.** The collision check on connect and the unique index on `(provider, external_account_id)` ignored the channel's state, so an Instagram account or Facebook Page connected once could never be connected under another client, even after Disconnect. Ownership now follows the credentials: only rows that still hold an access token count, and Disconnect already clears it. The old row keeps its conversations. An account that is still connected elsewhere is still refused with 409.
- **Migration 0037** narrows the partial unique index to rows with a token. Additive, no data change; downgrade restores the previous predicate.
- **Sender names.** Webhooks only carry the sender id, so social contacts were created without a name and conversations were titled "Contact". The first message from an unnamed contact now reads the sender profile on the provider (`first_name,last_name,name` on Messenger, `name,username` on Instagram), names the contact, stores the handle on the identity and retitles the conversations. One lookup per person; a failed lookup leaves the message untouched and the contact is named on a later message.

## Verified

- New tests: disconnect then connect under another client succeeds and the first client is refused afterwards; the profile lookup runs once, names the case, falls back to the Instagram handle, and a failed lookup never blocks the message.
- Full API suite: 272 passed.
- `alembic upgrade head` and `downgrade -1` on a fresh database, index predicate checked both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmvXrSAa61dmpRxx5LYMcR