### PR TITLE
Support WhatsApp Business app coexistence events and history

### DIFF
--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -272,6 +272,8 @@ class WhatsAppCloudChannel(Base):
     display_name: Mapped[str | None] = mapped_column(String(180), nullable=True)
     phone_number_id: Mapped[str] = mapped_column(String(80), default="", server_default="")
     waba_id: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    coexistence: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    coexistence_sync: Mapped[dict] = mapped_column(JSON, default=dict, server_default="{}")
     encrypted_access_token: Mapped[str | None] = mapped_column(Text, nullable=True)
     encrypted_app_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Token the owner pastes into their Meta app's webhook config; it must be
@@ -286,6 +288,25 @@ class WhatsAppCloudChannel(Base):
     client: Mapped[Client] = relationship(back_populates="whatsapp_cloud_channel")
     agent: Mapped[Agent] = relationship(back_populates="whatsapp_cloud_channels")
     conversations: Mapped[list["Conversation"]] = relationship(back_populates="whatsapp_cloud_channel")
+
+
+class WhatsAppCoexistenceEvent(Base):
+    """Durable imports and media enrichment, deduplicated before acknowledgement."""
+
+    __tablename__ = "whatsapp_coexistence_events"
+    __table_args__ = (UniqueConstraint("channel_id", "event_key", name="uq_whatsapp_coexistence_event"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=new_uuid)
+    channel_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("whatsapp_cloud_channels.id", ondelete="CASCADE"), index=True)
+    event_key: Mapped[str] = mapped_column(String(64))
+    field: Mapped[str] = mapped_column(String(40))
+    payload: Mapped[dict] = mapped_column(JSON)
+    cursor: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    attempts: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    available_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=now_utc, index=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=now_utc)
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
 
 
 class AgentQA(Base):
@@ -386,6 +407,8 @@ class Contact(Base):
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=new_uuid)
     client_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("clients.id", ondelete="CASCADE"), index=True)
     name: Mapped[str] = mapped_column(String(180), default="")
+    whatsapp_contact_name: Mapped[str | None] = mapped_column(String(180), nullable=True)
+    whatsapp_contact_updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # Digits only, as WhatsApp reports it. None for people without a number.
     phone: Mapped[str | None] = mapped_column(String(40), nullable=True)
     email: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -486,6 +509,9 @@ class Conversation(Base):
     messages: Mapped[list["Message"]] = relationship(back_populates="conversation", cascade="all, delete-orphan", order_by="Message.created_at")
 
     def _reply_policy(self) -> dict:
+        if self.channel == "whatsapp_cloud" and self.whatsapp_cloud_channel and self.whatsapp_cloud_channel.coexistence:
+            from .services.whatsapp_coexistence import window_fields
+            return window_fields(self)
         if self.channel in ("instagram", "messenger"):
             from .services.social_policy import window_fields
             return window_fields(self)

--- a/apps/api/app/routers/whatsapp_cloud.py
+++ b/apps/api/app/routers/whatsapp_cloud.py
@@ -95,6 +95,11 @@ def configure_channel(
             status_code=400, detail="That phone number is already connected to another client"
         )
     channel = db.scalar(select(WhatsAppCloudChannel).where(WhatsAppCloudChannel.client_id == client.id))
+    if channel and channel.coexistence and (
+        payload.phone_number_id is not None or payload.waba_id is not None
+        or payload.access_token or payload.app_secret
+    ):
+        raise HTTPException(status_code=409, detail="Use the WhatsApp Business app connection flow to change this number or its authorization.")
     if not channel:
         channel = WhatsAppCloudChannel(
             agency_id=user.agency_id,
@@ -104,7 +109,8 @@ def configure_channel(
         )
         db.add(channel)
     channel.agent_id = agent.id
-    channel.is_enabled = True
+    if not channel.coexistence:
+        channel.is_enabled = True
     if payload.phone_number_id is not None:
         channel.phone_number_id = number
     if payload.waba_id is not None:
@@ -154,6 +160,8 @@ async def connect_channel(client_id: uuid.UUID, db: Session = Depends(get_db), u
 @router.post("/channels/{client_id}/disconnect", response_model=WhatsAppCloudChannelOut)
 def disconnect_channel(client_id: uuid.UUID, db: Session = Depends(get_db), user: User = Depends(get_current_user)):
     channel = _channel_for_user(db, user, client_id)
+    if channel.coexistence:
+        raise HTTPException(status_code=409, detail="Disconnect this number in WhatsApp Business: Settings > Account > Business Platform > Disconnect account.")
     channel.status = "disconnected"
     channel.is_enabled = False
     channel.last_error = None

--- a/apps/api/app/routers/whatsapp_cloud.py
+++ b/apps/api/app/routers/whatsapp_cloud.py
@@ -41,6 +41,8 @@ def _public_channel(channel: WhatsAppCloudChannel) -> dict:
         "display_name": channel.display_name,
         "phone_number_id": channel.phone_number_id,
         "waba_id": channel.waba_id,
+        "coexistence": channel.coexistence,
+        "coexistence_sync": channel.coexistence_sync,
         "has_access_token": bool(channel.encrypted_access_token),
         "has_app_secret": bool(channel.encrypted_app_secret),
         "webhook_url": webhook_url,

--- a/apps/api/app/routers/whatsapp_cloud_webhook.py
+++ b/apps/api/app/routers/whatsapp_cloud_webhook.py
@@ -60,10 +60,12 @@ def _parse_message(message: dict, contacts: dict[str, str]) -> InboundMessage | 
     """Map one Cloud API message to the shared inbound shape; None to skip."""
     kind = message.get("type")
     sender = message.get("from") or ""
+    from ..services.social_inbound import event_time
     base = {
         "external_message_id": message.get("id") or "",
         "external_chat_id": sender,
         "sender_name": contacts.get(sender),
+        "occurred_at": event_time(message.get("timestamp")),
     }
     if not base["external_message_id"] or not sender:
         return None
@@ -133,6 +135,10 @@ async def receive_webhook(channel_id: uuid.UUID, request: Request, db: Session =
     access_token = decrypt_secret(channel.encrypted_access_token) if channel.encrypted_access_token else None
     for entry in payload.get("entry") or []:
         for change in entry.get("changes") or []:
+            from ..services.whatsapp_coexistence import FIELDS, accept_change
+            if change.get("field") in FIELDS:
+                accept_change(db, channel, change["field"], change.get("value") or {}, waba_id=str(entry.get("id") or ""))
+                continue
             if change.get("field") != "messages":
                 continue
             value = change.get("value") or {}

--- a/apps/api/app/schemas_whatsapp_cloud.py
+++ b/apps/api/app/schemas_whatsapp_cloud.py
@@ -22,6 +22,8 @@ class WhatsAppCloudChannelOut(BaseModel):
     display_name: str | None
     phone_number_id: str
     waba_id: str | None
+    coexistence: bool = False
+    coexistence_sync: dict = Field(default_factory=dict)
     has_access_token: bool
     has_app_secret: bool
     webhook_url: str

--- a/apps/api/app/services/social_worker.py
+++ b/apps/api/app/services/social_worker.py
@@ -153,11 +153,15 @@ async def _loop() -> None:
 def start_worker() -> None:
     global _task
     if get_settings().social_worker_enabled and (_task is None or _task.done()):
+        from . import whatsapp_coexistence
+        whatsapp_coexistence.start_worker()
         _task = asyncio.create_task(_loop())
 
 
 async def stop_worker() -> None:
     global _task
+    from . import whatsapp_coexistence
+    await whatsapp_coexistence.stop_worker()
     task, _task = _task, None
     if task:
         task.cancel()

--- a/apps/api/app/services/whatsapp.py
+++ b/apps/api/app/services/whatsapp.py
@@ -64,6 +64,9 @@ async def send_channel_message(
         if not conversation.whatsapp_cloud_channel_id or not conversation.external_chat_id:
             raise HTTPException(status_code=409, detail="This conversation does not have a valid WhatsApp destination")
         channel = db.get(WhatsAppCloudChannel, conversation.whatsapp_cloud_channel_id)
+        from .whatsapp_coexistence import require_reply
+        if channel and channel.coexistence:
+            require_reply(conversation)
         if not channel or not channel.encrypted_access_token or not channel.phone_number_id:
             raise HTTPException(status_code=409, detail="The WhatsApp API channel is not configured")
         return await send_text(
@@ -122,6 +125,9 @@ async def send_channel_media(
         if not conversation.whatsapp_cloud_channel_id or not conversation.external_chat_id:
             raise HTTPException(status_code=409, detail="This conversation does not have a valid WhatsApp destination")
         channel = db.get(WhatsAppCloudChannel, conversation.whatsapp_cloud_channel_id)
+        from .whatsapp_coexistence import require_reply
+        if channel and channel.coexistence:
+            require_reply(conversation)
         if not channel or not channel.encrypted_access_token or not channel.phone_number_id:
             raise HTTPException(status_code=409, detail="The WhatsApp API channel is not configured")
         access_token = decrypt_secret(channel.encrypted_access_token)
@@ -183,6 +189,9 @@ async def signal_channel_read(
         return
     if conversation.channel == "whatsapp_cloud" and conversation.whatsapp_cloud_channel_id:
         channel = db.get(WhatsAppCloudChannel, conversation.whatsapp_cloud_channel_id)
+        from .whatsapp_coexistence import require_reply
+        if channel and channel.coexistence:
+            require_reply(conversation)
         if not channel or not channel.encrypted_access_token or not channel.phone_number_id:
             return
         access_token = decrypt_secret(channel.encrypted_access_token)
@@ -215,6 +224,9 @@ async def deliver_reaction(db: Session, conversation: Conversation, target, emoj
         return
     if conversation.channel == "whatsapp_cloud":
         channel = db.get(WhatsAppCloudChannel, conversation.whatsapp_cloud_channel_id)
+        from .whatsapp_coexistence import require_reply
+        if channel and channel.coexistence:
+            require_reply(conversation)
         if not channel or not channel.encrypted_access_token or not channel.phone_number_id:
             raise HTTPException(status_code=409, detail="The WhatsApp API channel is not configured")
         await send_reaction(

--- a/apps/api/app/services/whatsapp_coexistence.py
+++ b/apps/api/app/services/whatsapp_coexistence.py
@@ -1,0 +1,395 @@
+"""Mirror Business app activity without replaying it through the agent.
+
+History is a durable, bounded import. Phone replies take over immediately in
+the receipt transaction; downloading their attachments is separate work.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import uuid
+from datetime import timedelta
+
+from fastapi import HTTPException
+from sqlalchemy import case, delete, literal, or_, select, text, update
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import selectinload
+
+from ..config import get_settings
+from ..database import new_session
+from ..models import Contact, Conversation, Message, WhatsAppCloudChannel, WhatsAppCoexistenceEvent, new_uuid, now_utc
+from ..security import decrypt_secret
+from .attachments import ensure_uploadable, store_attachment
+from .contacts import normalize_phone
+from .social_inbound import event_time
+from .whatsapp_cloud import _graph_request, _graph_url, fetch_media
+
+logger = logging.getLogger(__name__)
+FIELDS = frozenset({"history", "smb_app_state_sync", "smb_message_echoes", "account_update"})
+_task = None
+_scope_runner = None
+
+
+def lock_chats(db, channel_id, peers):
+    keys = sorted({int.from_bytes(hashlib.sha256(f"{channel_id}:{peer}".encode()).digest()[:8], "big", signed=True) for peer in peers})
+    if keys:
+        db.execute(text("SELECT pg_advisory_xact_lock(key) FROM unnest(CAST(:keys AS bigint[])) AS key ORDER BY key"), {"keys": keys})
+
+
+def window_fields(conversation):
+    channel = conversation.whatsapp_cloud_channel
+    last = conversation.social_last_inbound_at
+    until = last + timedelta(hours=24) if last else None
+    reason = None
+    if not channel or not channel.is_enabled or channel.status != "connected":
+        reason = "channel_disconnected"
+    elif conversation.status == "resolved":
+        reason = "conversation_resolved"
+    elif not until or until <= now_utc():
+        reason = "reply_window_closed"
+    return {"reply_window_until": until, "reply_window_open": reason is None,
+            "human_reply_window_until": until, "human_reply_window_open": reason is None, "reply_block_reason": reason}
+
+
+def require_reply(conversation):
+    channel = conversation.whatsapp_cloud_channel
+    if channel and channel.coexistence and not window_fields(conversation)["reply_window_open"]:
+        raise HTTPException(status_code=409, detail="Wait for a new customer message before replying from the Inbox, or reply from WhatsApp Business on your phone.")
+
+
+def sync_state(db, channel, section: str, **values):
+    # Another transaction may have received progress while a Graph call ran.
+    channel = db.scalar(select(WhatsAppCloudChannel).where(WhatsAppCloudChannel.id == channel.id)
+                        .with_for_update().execution_options(populate_existing=True))
+    state = dict(channel.coexistence_sync or {})
+    state[section] = {**state.get(section, {}), **values}
+    channel.coexistence_sync = state
+    db.flush()
+    return channel
+
+
+def _enqueue(db, channel, field, value):
+    key = hashlib.sha256(json.dumps([field, value], sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    db.execute(insert(WhatsAppCoexistenceEvent).values(
+        id=new_uuid(), channel_id=channel.id, field=field, event_key=key, payload=value,
+        cursor=0, attempts=0, available_at=now_utc(), created_at=now_utc(),
+    ).on_conflict_do_nothing(constraint="uq_whatsapp_coexistence_event"))
+
+
+def _text(raw):
+    kind = raw.get("type", "unsupported")
+    content = raw.get(kind) or {}
+    if kind == "text":
+        return str(content.get("body") or "")
+    if kind == "location":
+        return str(content.get("name") or content.get("address") or "[Location]")
+    if kind == "contacts":
+        return "[Contact]"
+    return str(content.get("caption") or content.get("filename") or f"[{kind.replace('_', ' ').capitalize()}]")
+
+
+def _messages(db, channel, rows, *, historical):
+    """Bulk lookups keep a large history chunk from issuing queries per message."""
+    rows = [(peer, raw) for peer, raw in rows if normalize_phone(peer) and raw.get("id") and event_time(raw.get("timestamp"))]
+    if not rows:
+        return
+    peers = {peer for peer, _ in rows}
+    lock_chats(db, channel.id, peers)
+    existing = {m.external_message_id: m for m in db.scalars(select(Message).join(Conversation).where(
+        Conversation.whatsapp_cloud_channel_id == channel.id,
+        Message.external_message_id.in_([str(raw["id"]) for _, raw in rows]))).all()}
+    contacts = {c.phone: c for c in db.scalars(select(Contact).where(Contact.client_id == channel.client_id, Contact.phone.in_(peers)))}
+    missing = peers - contacts.keys()
+    if missing:
+        db.execute(insert(Contact).values([dict(id=new_uuid(), client_id=channel.client_id, phone=peer, name="") for peer in missing])
+                   .on_conflict_do_nothing(index_elements=["client_id", "phone"], index_where=Contact.phone.is_not(None)))
+        contacts = {c.phone: c for c in db.scalars(select(Contact).where(Contact.client_id == channel.client_id, Contact.phone.in_(peers)))}
+    conversations = db.scalars(select(Conversation).where(Conversation.whatsapp_cloud_channel_id == channel.id,
+        Conversation.external_chat_id.in_(peers)).order_by(Conversation.created_at.desc())).all()
+    by_peer = {}
+    for conversation in conversations:
+        wanted = conversation.id == uuid.uuid5(channel.id, "history:" + conversation.external_chat_id) if historical else conversation.status != "resolved"
+        if wanted:
+            by_peer.setdefault(conversation.external_chat_id, conversation)
+    business = normalize_phone(channel.phone_number)
+    for peer, raw in rows:
+        mid = str(raw["id"])
+        if mid in existing:
+            continue
+        occurred = event_time(raw["timestamp"])
+        outgoing = not historical or normalize_phone(raw.get("from")) == business or raw.get("to") == peer
+        contact = contacts[peer]
+        conversation = by_peer.get(peer)
+        if not conversation:
+            conversation = Conversation(id=uuid.uuid5(channel.id, "history:" + peer) if historical else new_uuid(),
+                agency_id=channel.agency_id, client_id=channel.client_id, agent_id=channel.agent_id,
+                channel="whatsapp_cloud", whatsapp_cloud_channel_id=channel.id, external_chat_id=peer,
+                title=(contact.name or "+" + peer)[:240], contact_id=contact.id, contact_name=contact.name or None,
+                mode="human", status="resolved" if historical else "open", created_at=occurred, updated_at=occurred,
+                resolved_at=occurred if historical else None)
+            db.add(conversation)
+            by_peer[peer] = conversation
+        if historical:
+            conversation.created_at = min(conversation.created_at, occurred)
+            conversation.resolved_at = max(conversation.resolved_at or occurred, occurred)
+        else:
+            # A retry is deduplicated above, so it cannot take over again after
+            # an operator has explicitly returned the conversation to the AI.
+            conversation.mode = "human"
+            conversation.taken_over_at = now_utc()
+            conversation.social_reply_due_at = None
+            conversation.social_reply_claimed_until = None
+            if not conversation.waiting_since or occurred + timedelta(seconds=1) >= conversation.waiting_since:
+                conversation.waiting_since = None
+            conversation.first_reply_at = conversation.first_reply_at or occurred
+        conversation.updated_at = max(conversation.updated_at, occurred)
+        state = str((raw.get("history_context") or {}).get("status", "sent")).lower()
+        message = Message(id=new_uuid(), conversation_id=conversation.id, external_message_id=mid,
+            role="assistant" if outgoing else "user", content=_text(raw), is_historical=historical,
+            sender_type="human" if outgoing else "visitor", sender_name="WhatsApp Business" if outgoing else contact.name,
+            delivery_status={"played": "read", "error": "failed", "pending": "pending"}.get(state, state) if outgoing else None,
+            created_at=occurred)
+        db.add(message)
+        existing[mid] = message
+    db.flush()
+    for peer, raw in rows:
+        media = raw.get(raw.get("type")) or {}
+        if isinstance(media, dict) and media.get("id") and raw.get("type") in {"image", "audio", "video", "document", "sticker"}:
+            _enqueue(db, channel, "media", {"message_id": str(raw["id"]), "raw": raw})
+
+
+def accept_change(db, channel, field: str, value: dict, *, waba_id: str = "") -> bool:
+    """Caller must verify the signature. Failure to commit must cause a retry."""
+    if field not in FIELDS or not channel.coexistence:
+        return False
+    delivered = (value.get("metadata") or {}).get("phone_number_id")
+    if field == "account_update":
+        if not waba_id or waba_id != channel.waba_id:
+            return False
+        phone = normalize_phone(value.get("phone_number"))
+        if phone and phone != normalize_phone(channel.phone_number):
+            return False
+        if value.get("event") in {"PARTNER_REMOVED", "ACCOUNT_OFFBOARDED"}:
+            channel.status = "disconnected"
+            channel.is_enabled = False
+            channel.encrypted_access_token = None
+            channel.last_error = "WhatsApp Business disconnected this number. Connect it again to resume."
+            channel.coexistence_sync = {**(channel.coexistence_sync or {}), "offboarded_at": now_utc().isoformat()}
+        db.commit()
+        return True
+    if delivered != channel.phone_number_id or not channel.is_enabled:
+        return False
+    if field == "smb_message_echoes":
+        business = normalize_phone(channel.phone_number)
+        rows = [(normalize_phone(raw.get("to")), raw) for raw in value.get("message_echoes", [])
+                if business and normalize_phone(raw.get("from")) == business]
+        _messages(db, channel, rows, historical=False)
+    else:
+        _enqueue(db, channel, field, value)
+    db.commit()
+    return True
+
+
+async def request_sync(db, channel):
+    """Persist intent before either one-shot request. Never retry an unknown send."""
+    for section, sync_type in (("contacts", "smb_app_state_sync"), ("history", "history")):
+        channel = db.scalar(select(WhatsAppCloudChannel).where(WhatsAppCloudChannel.id == channel.id)
+                            .with_for_update().execution_options(populate_existing=True))
+        state = (channel.coexistence_sync or {}).get(section, {})
+        if not channel.is_enabled or not channel.encrypted_access_token or state.get("status") != "pending":
+            db.rollback()
+            continue
+        started = event_time((channel.coexistence_sync or {}).get("started_at"))
+        if started and now_utc() - started >= timedelta(hours=24):
+            sync_state(db, channel, section, status="error", error="The synchronization window expired. Disconnect in WhatsApp Business before onboarding again.")
+            db.commit()
+            continue
+        sync_state(db, channel, section, status="requesting", requested_at=now_utc().isoformat())
+        access_token = decrypt_secret(channel.encrypted_access_token)
+        phone = channel.phone_number_id
+        db.commit()
+        try:
+            response = await _graph_request("POST", _graph_url(f"{phone}/smb_app_data"), access_token,
+                json={"messaging_product": "whatsapp", "sync_type": sync_type})
+            result = response.json()
+            if response.status_code >= 400 or not result.get("request_id"):
+                sync_state(db, channel, section, status="error", error="Meta did not accept the synchronization request.")
+            else:
+                current = db.scalar(select(WhatsAppCloudChannel).where(WhatsAppCloudChannel.id == channel.id)
+                                    .with_for_update().execution_options(populate_existing=True))
+                status = (current.coexistence_sync or {}).get(section, {}).get("status")
+                sync_state(db, channel, section, status="requested" if status == "requesting" else status,
+                           request_id=str(result["request_id"]))
+        except (HTTPException, ValueError):
+            sync_state(db, channel, section, status="unknown", error="Meta's response was not received. Do not repeat onboarding until the synchronization status is checked.")
+        db.commit()
+
+
+def _history_rows(value):
+    for batch in value.get("history", []):
+        for thread in batch.get("threads", []):
+            peer = normalize_phone(thread.get("id"))
+            if peer:
+                for raw in thread.get("messages", []):
+                    yield peer, raw
+
+
+def _contacts(db, channel, rows):
+    latest = {}
+    for row in rows:
+        if row.get("type") != "contact" or row.get("action") not in {"add", "remove"}:
+            continue
+        raw = row.get("contact") or {}
+        phone = normalize_phone(raw.get("phone_number"))
+        occurred = event_time((row.get("metadata") or {}).get("timestamp"))
+        if not phone or not occurred or (phone in latest and latest[phone][0] >= occurred):
+            continue
+        name = str(raw.get("full_name") or raw.get("first_name") or "")[:180] if row["action"] == "add" else ""
+        latest[phone] = (occurred, name)
+    if not latest:
+        return
+    statement = insert(Contact).values([dict(id=new_uuid(), client_id=channel.client_id, phone=phone, name=name,
+        whatsapp_contact_name=name, whatsapp_contact_updated_at=occurred)
+        for phone, (occurred, name) in latest.items()])
+    # A phone-book removal removes only the synchronized label. Local names,
+    # notes, blocked status and conversations remain owned by the operator.
+    db.execute(statement.on_conflict_do_update(index_elements=["client_id", "phone"], index_where=Contact.phone.is_not(None),
+        set_={"name": case((or_(Contact.name == "", Contact.name == Contact.whatsapp_contact_name), statement.excluded.name), else_=Contact.name),
+              "whatsapp_contact_name": statement.excluded.whatsapp_contact_name,
+              "whatsapp_contact_updated_at": statement.excluded.whatsapp_contact_updated_at},
+        where=or_(Contact.whatsapp_contact_updated_at.is_(None), Contact.whatsapp_contact_updated_at < statement.excluded.whatsapp_contact_updated_at)))
+    db.execute(update(Conversation).where(Conversation.contact_id == Contact.id, Contact.client_id == channel.client_id,
+        Contact.phone.in_(latest)).values(contact_name=Contact.name,
+        title=case((Contact.name != "", Contact.name), else_=literal("+") + Contact.phone)))
+    db.flush()
+
+
+async def process_pending(db, *, limit=2, batch_size=100):
+    for _ in range(limit):
+        item = db.scalar(select(WhatsAppCoexistenceEvent).where(WhatsAppCoexistenceEvent.processed_at.is_(None),
+            WhatsAppCoexistenceEvent.available_at <= now_utc(), WhatsAppCoexistenceEvent.attempts < 8)
+            .order_by(WhatsAppCoexistenceEvent.available_at).with_for_update(skip_locked=True).limit(1))
+        if not item:
+            db.rollback()
+            break
+        item_id = item.id
+        try:
+            channel = db.get(WhatsAppCloudChannel, item.channel_id)
+            if not channel or not channel.coexistence or not channel.is_enabled:
+                item.payload = {}
+                item.processed_at = now_utc()
+                db.commit()
+                continue
+            value = item.payload
+            done = True
+            if item.field == "history":
+                rows = list(_history_rows(value))
+                _messages(db, channel, rows[item.cursor:item.cursor + batch_size], historical=True)
+                item.cursor += batch_size
+                done = item.cursor >= len(rows)
+                if done:
+                    for batch in value.get("history", []):
+                        for error in batch.get("errors", []):
+                            sync_state(db, channel, "history", status="declined" if error.get("code") == 2593109 else "error")
+                        progress = (batch.get("metadata") or {}).get("progress")
+                        if isinstance(progress, int):
+                            prior = (channel.coexistence_sync or {}).get("history", {}).get("progress", 0)
+                            progress = min(100, max(prior, progress))
+                            other_pending = db.scalar(select(WhatsAppCoexistenceEvent.id).where(
+                                WhatsAppCoexistenceEvent.channel_id == channel.id, WhatsAppCoexistenceEvent.id != item.id,
+                                WhatsAppCoexistenceEvent.field == "history", WhatsAppCoexistenceEvent.processed_at.is_(None)).limit(1))
+                            sync_state(db, channel, "history", progress=progress,
+                                       status="complete" if progress == 100 and not other_pending else "syncing")
+                    # Media-only history envelopes can precede their text chunk.
+                    for raw in value.get("messages", []):
+                        _enqueue(db, channel, "media", {"message_id": str(raw.get("id", "")), "raw": raw})
+            elif item.field == "smb_app_state_sync":
+                rows = value.get("state_sync", [])
+                _contacts(db, channel, rows[item.cursor:item.cursor + batch_size])
+                item.cursor += batch_size
+                done = item.cursor >= len(rows)
+                if done:
+                    sync_state(db, channel, "contacts", status="syncing", last_received_at=now_utc().isoformat())
+            elif item.field == "media":
+                message = db.scalar(select(Message).join(Conversation).where(
+                    Conversation.whatsapp_cloud_channel_id == channel.id, Message.external_message_id == value["message_id"])
+                    .options(selectinload(Message.attachments)))
+                if not message:
+                    raise ValueError("Waiting for the corresponding history message")
+                if not message.attachments:
+                    raw = value["raw"]
+                    media = raw.get(raw.get("type")) or {}
+                    data, mime = await fetch_media(decrypt_secret(channel.encrypted_access_token), media["id"])
+                    ensure_uploadable(mime)
+                    store_attachment(db, message, data=data, mime=mime, filename=media.get("filename"))
+                    if message.content == "[Media placeholder]":
+                        message.content = _text(raw)
+            if done:
+                item.processed_at = now_utc()
+                item.payload = {}
+            else:
+                # Other accounts and small media jobs get a turn between chunks.
+                item.available_at = now_utc() + timedelta(seconds=1)
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            db.execute(update(WhatsAppCoexistenceEvent).where(WhatsAppCoexistenceEvent.id == item_id).values(
+                attempts=WhatsAppCoexistenceEvent.attempts + 1, available_at=now_utc() + timedelta(seconds=60),
+                last_error=type(exc).__name__))
+            db.commit()
+            logger.warning("WhatsApp synchronization deferred for %s (%s)", item_id, type(exc).__name__)
+
+
+async def run_scope(db):
+    ids = db.scalars(select(WhatsAppCloudChannel.id).where(WhatsAppCloudChannel.coexistence.is_(True),
+        WhatsAppCloudChannel.is_enabled.is_(True))).all()
+    for channel_id in ids:
+        channel = db.get(WhatsAppCloudChannel, channel_id)
+        for part in ("contacts", "history"):
+            state = (channel.coexistence_sync or {}).get(part, {})
+            requested_at = event_time(state.get("requested_at"))
+            if state.get("status") == "requesting" and requested_at and now_utc() - requested_at > timedelta(minutes=5):
+                sync_state(db, channel, part, status="unknown", error="The server restarted before Meta's response was recorded. Check synchronization before reconnecting.")
+                db.commit()
+        if any((channel.coexistence_sync or {}).get(part, {}).get("status") == "pending" for part in ("contacts", "history")):
+            await request_sync(db, channel)
+    await process_pending(db)
+    db.execute(delete(WhatsAppCoexistenceEvent).where(WhatsAppCoexistenceEvent.processed_at < now_utc() - timedelta(days=30)))
+    db.commit()
+
+
+def install_scope_runner(runner):
+    global _scope_runner
+    _scope_runner = runner
+
+
+async def _loop():
+    while True:
+        await asyncio.sleep(max(0.5, get_settings().social_worker_interval_seconds))
+        try:
+            if _scope_runner:
+                await _scope_runner(run_scope)
+            else:
+                with new_session() as db:
+                    await run_scope(db)
+        except Exception as exc:
+            logger.warning("WhatsApp synchronization worker failed (%s)", type(exc).__name__)
+
+
+def start_worker():
+    global _task
+    if _task is None or _task.done():
+        _task = asyncio.create_task(_loop())
+
+
+async def stop_worker():
+    global _task
+    task, _task = _task, None
+    if task:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/apps/api/app/services/whatsapp_coexistence.py
+++ b/apps/api/app/services/whatsapp_coexistence.py
@@ -294,7 +294,7 @@ async def process_pending(db, *, limit=2, batch_size=100):
                         for error in batch.get("errors", []):
                             sync_state(db, channel, "history", status="declined" if error.get("code") == 2593109 else "error")
                         progress = (batch.get("metadata") or {}).get("progress")
-                        if isinstance(progress, int):
+                        if isinstance(progress, int) and not batch.get("errors"):
                             prior = (channel.coexistence_sync or {}).get("history", {}).get("progress", 0)
                             progress = min(100, max(prior, progress))
                             other_pending = db.scalar(select(WhatsAppCoexistenceEvent.id).where(
@@ -335,9 +335,14 @@ async def process_pending(db, *, limit=2, batch_size=100):
             db.commit()
         except Exception as exc:
             db.rollback()
-            db.execute(update(WhatsAppCoexistenceEvent).where(WhatsAppCoexistenceEvent.id == item_id).values(
+            attempts = db.execute(update(WhatsAppCoexistenceEvent).where(WhatsAppCoexistenceEvent.id == item_id).values(
                 attempts=WhatsAppCoexistenceEvent.attempts + 1, available_at=now_utc() + timedelta(seconds=60),
-                last_error=type(exc).__name__))
+                last_error=type(exc).__name__).returning(WhatsAppCoexistenceEvent.attempts)).scalar_one()
+            if attempts >= 8:
+                failed = db.get(WhatsAppCoexistenceEvent, item_id)
+                channel = db.get(WhatsAppCloudChannel, failed.channel_id)
+                section = "contacts" if failed.field == "smb_app_state_sync" else failed.field
+                sync_state(db, channel, section, status="error", error="Some synchronization data could not be processed. Contact support.")
             db.commit()
             logger.warning("WhatsApp synchronization deferred for %s (%s)", item_id, type(exc).__name__)
 
@@ -356,7 +361,9 @@ async def run_scope(db):
         if any((channel.coexistence_sync or {}).get(part, {}).get("status") == "pending" for part in ("contacts", "history")):
             await request_sync(db, channel)
     await process_pending(db)
-    db.execute(delete(WhatsAppCoexistenceEvent).where(WhatsAppCoexistenceEvent.processed_at < now_utc() - timedelta(days=30)))
+    db.execute(delete(WhatsAppCoexistenceEvent).where(or_(
+        WhatsAppCoexistenceEvent.processed_at < now_utc() - timedelta(days=30),
+        (WhatsAppCoexistenceEvent.attempts >= 8) & (WhatsAppCoexistenceEvent.created_at < now_utc() - timedelta(days=30)))))
     db.commit()
 
 

--- a/apps/api/app/services/whatsapp_inbound.py
+++ b/apps/api/app/services/whatsapp_inbound.py
@@ -123,6 +123,9 @@ async def process_inbound(
     same fields used here. ``conversation_channel`` and ``channel_fk_field``
     select the Conversation channel label and FK column for the caller.
     """
+    if conversation_channel == "whatsapp_cloud" and channel.coexistence:
+        from .whatsapp_coexistence import lock_chats
+        lock_chats(db, channel.id, [inbound.external_chat_id])
     fk_column = getattr(Conversation, channel_fk_field)
 
     existing = db.scalar(
@@ -204,6 +207,9 @@ async def process_inbound(
     blocked = conversation.contact is not None and conversation.contact.blocked_at is not None
     if not blocked:
         note_inbound(db, conversation)
+    if conversation_channel == "whatsapp_cloud" and channel.coexistence:
+        occurred = inbound.occurred_at or now_utc()
+        conversation.social_last_inbound_at = max(conversation.social_last_inbound_at or occurred, occurred)
     if conversation_channel in ("instagram", "messenger") and inbound.occurred_at:
         last = conversation.social_last_inbound_at
         if not last or inbound.occurred_at > last:
@@ -239,7 +245,7 @@ async def process_inbound(
         return InboundResult(accepted=True, conversation_id=conversation.id, mode="ai")
 
     await _signal_read_and_typing(db, conversation, [inbound.external_message_id])
-    return await _reply_with_ai(db, channel, conversation, llm_content)
+    return await _reply_with_ai(db, channel, conversation, llm_content, expected_last_message_id=visitor_message.id)
 
 
 # Injected into the system prompt for WhatsApp conversations on both channels
@@ -320,6 +326,15 @@ async def _reply_with_ai(db: Session, channel, conversation: Conversation, retri
     text on the synchronous path, or the whole visitor burst when debounced.
     """
     agent = channel.agent
+    db.refresh(conversation)
+    if conversation.mode == "human" or conversation.status == "resolved" or not channel.is_enabled:
+        return InboundResult(accepted=True, conversation_id=conversation.id, mode=conversation.mode)
+    if conversation.channel == "whatsapp_cloud" and channel.coexistence:
+        from .whatsapp_coexistence import require_reply
+        try:
+            require_reply(conversation)
+        except HTTPException:
+            return InboundResult(accepted=True, conversation_id=conversation.id, mode=conversation.mode)
     if not channel.client.is_active:
         # An inactive client is switched off everywhere: the message is kept
         # for the record, nobody answers it and no tokens are spent.
@@ -389,6 +404,20 @@ async def _reply_with_ai(db: Session, channel, conversation: Conversation, retri
         return InboundResult(accepted=True, conversation_id=conversation.id, mode=conversation.mode)
 
     reply_text = completion.text
+    if conversation.channel in ("whatsapp", "whatsapp_cloud"):
+        # A Business app echo or an operator may take over during generation.
+        # Re-read persisted state; cancelling an in-process timer is not enough
+        # when the webhook was received by another process or event loop.
+        db.refresh(conversation)
+        db.refresh(channel)
+        last_message = db.scalar(select(Message).where(Message.conversation_id == conversation.id,
+            Message.kind == "message", Message.is_historical.is_(False)).order_by(Message.created_at.desc()).limit(1))
+        if (conversation.mode == "human" or conversation.status == "resolved" or not channel.is_enabled
+                or (last_message and last_message.role != "user")
+                or (expected_last_message_id and (not last_message or last_message.id != expected_last_message_id))):
+            record_usage(db, agent.agency_id, agent.id, agent.provider, agent.model.strip(), completion)
+            db.commit()
+            return InboundResult(accepted=True, conversation_id=conversation.id, mode=conversation.mode)
     if conversation.channel in ("instagram", "messenger"):
         from .social_policy import require_reply
         db.refresh(conversation)
@@ -530,7 +559,7 @@ async def _debounced_reply(conversation_id: uuid.UUID, delay: float) -> None:
         # The loop walks newest-first; read receipts go oldest-first.
         await _signal_read_and_typing(db, conversation, list(reversed(burst_external_ids)))
         try:
-            result = await _reply_with_ai(db, channel, conversation, "\n".join(reversed(burst)))
+            result = await _reply_with_ai(db, channel, conversation, "\n".join(reversed(burst)), expected_last_message_id=last.id)
         except Exception as exc:
             channel.last_error = f"Message received, but the agent could not reply: {str(exc)[:400]}"
             channel.updated_at = now_utc()

--- a/apps/api/migrations/versions/0037_whatsapp_coexistence.py
+++ b/apps/api/migrations/versions/0037_whatsapp_coexistence.py
@@ -1,0 +1,38 @@
+"""Persist WhatsApp Business app coexistence and resumable imports."""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0037_whatsapp_coexistence"
+down_revision = "0036_archive_and_agent_tombstone"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("contacts", sa.Column("whatsapp_contact_name", sa.String(180), nullable=True))
+    op.add_column("contacts", sa.Column("whatsapp_contact_updated_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("whatsapp_cloud_channels", sa.Column("coexistence", sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.add_column("whatsapp_cloud_channels", sa.Column("coexistence_sync", sa.JSON(), nullable=False, server_default="{}"))
+    op.create_table("whatsapp_coexistence_events",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("channel_id", sa.Uuid(), sa.ForeignKey("whatsapp_cloud_channels.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("event_key", sa.String(64), nullable=False),
+        sa.Column("field", sa.String(40), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("cursor", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("available_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_error", sa.Text()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("processed_at", sa.DateTime(timezone=True)),
+        sa.UniqueConstraint("channel_id", "event_key", name="uq_whatsapp_coexistence_event"))
+    for column in ("channel_id", "available_at", "processed_at"):
+        op.create_index(f"ix_whatsapp_coexistence_events_{column}", "whatsapp_coexistence_events", [column])
+
+
+def downgrade():
+    op.drop_column("contacts", "whatsapp_contact_updated_at")
+    op.drop_column("contacts", "whatsapp_contact_name")
+    op.drop_table("whatsapp_coexistence_events")
+    op.drop_column("whatsapp_cloud_channels", "coexistence_sync")
+    op.drop_column("whatsapp_cloud_channels", "coexistence")

--- a/apps/api/migrations/versions/0038_whatsapp_coexistence.py
+++ b/apps/api/migrations/versions/0038_whatsapp_coexistence.py
@@ -2,8 +2,8 @@
 from alembic import op
 import sqlalchemy as sa
 
-revision = "0037_whatsapp_coexistence"
-down_revision = "0036_archive_and_agent_tombstone"
+revision = "0038_whatsapp_coexistence"
+down_revision = "0037_release_social_accounts"
 branch_labels = None
 depends_on = None
 

--- a/apps/api/tests/test_outbound_voice_recording.py
+++ b/apps/api/tests/test_outbound_voice_recording.py
@@ -79,7 +79,7 @@ def test_both_outbound_channels_receive_valid_voice_media(tmp_path, monkeypatch,
         channel=channel, whatsapp_channel_id="qr-line", whatsapp_cloud_channel_id="api-line",
         external_chat_id="573001234567",
     )
-    db = SimpleNamespace(get=lambda model, key: SimpleNamespace(encrypted_access_token="encrypted", phone_number_id="phone-id"))
+    db = SimpleNamespace(get=lambda model, key: SimpleNamespace(encrypted_access_token="encrypted", phone_number_id="phone-id", coexistence=False))
     result = asyncio.run(whatsapp.send_channel_media(
         db, conversation, kind="audio", data=original, mime="audio/mp4", filename="voice-note.m4a", caption="Listen to this",
     ))

--- a/apps/api/tests/test_whatsapp_cloud.py
+++ b/apps/api/tests/test_whatsapp_cloud.py
@@ -368,7 +368,7 @@ def test_transcoded_voice_note_uploads_with_ogg_filename(monkeypatch):
     monkeypatch.setattr(whatsapp_service, "send_media", fake_send)
     monkeypatch.setattr(whatsapp_service, "decrypt_secret", lambda value: "token")
 
-    channel = SimpleNamespace(encrypted_access_token="enc", phone_number_id="111")
+    channel = SimpleNamespace(encrypted_access_token="enc", phone_number_id="111", coexistence=False)
     conversation = SimpleNamespace(
         channel="whatsapp_cloud", whatsapp_cloud_channel_id="ch-1", external_chat_id="573001"
     )

--- a/apps/api/tests/test_whatsapp_coexistence.py
+++ b/apps/api/tests/test_whatsapp_coexistence.py
@@ -1,0 +1,262 @@
+import asyncio
+import uuid
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import event, select, update
+
+from app.models import Contact, Conversation, Message, WhatsAppCloudChannel, WhatsAppCoexistenceEvent, now_utc
+from app.services import whatsapp_coexistence as coex, whatsapp_inbound
+from app.services.ai import Completion
+from app.routers import whatsapp_cloud_webhook
+from conftest import TestingSession
+from test_whatsapp_cloud import _setup_channel, _post_signed, _webhook_payload
+
+BUSINESS = "15550783881"
+PERSON = "16505551234"
+
+
+@pytest.fixture
+def channel(authenticated_client):
+    _, _, data = _setup_channel(authenticated_client)
+    with TestingSession() as db:
+        channel = db.get(WhatsAppCloudChannel, uuid.UUID(data["id"]))
+        channel.phone_number = BUSINESS
+        channel.coexistence = True
+        channel.status = "connected"
+        channel.is_enabled = True
+        channel.coexistence_sync = {"history": {"status": "pending"}, "contacts": {"status": "pending"}}
+        db.commit()
+    return uuid.UUID(data["id"])
+
+
+def raw(mid, *, outgoing=False, age=60, kind="text"):
+    return {"id": mid, "from": BUSINESS if outgoing else PERSON,
+        "timestamp": str(int((now_utc() - timedelta(seconds=age)).timestamp())),
+        "type": kind, "text": {"body": mid}}
+
+
+def value(**parts):
+    return {"metadata": {"phone_number_id": "111", "display_phone_number": BUSINESS}, **parts}
+
+
+def receive(db, channel_id, field, body):
+    return coex.accept_change(db, db.get(WhatsAppCloudChannel, channel_id), field, body, waba_id="waba-1")
+
+
+def history(*messages, progress=100):
+    return value(history=[{"metadata": {"phase": 2, "chunk_order": 1, "progress": progress},
+        "threads": [{"id": PERSON, "messages": list(messages)}]}])
+
+
+def test_history_is_durable_bounded_and_never_replies(channel, monkeypatch):
+    ai = AsyncMock()
+    monkeypatch.setattr(whatsapp_inbound, "run_completion", ai)
+    payload = history(raw("old-in", age=86400), raw("old-out", outgoing=True, age=86000))
+    with TestingSession() as db:
+        receive(db, channel, "history", payload)
+        receive(db, channel, "history", payload)
+        assert len(db.scalars(select(WhatsAppCoexistenceEvent)).all()) == 1
+        assert not db.scalars(select(Message)).all()
+        asyncio.run(coex.process_pending(db, limit=1, batch_size=1))
+        assert len(db.scalars(select(Message)).all()) == 1
+        assert db.get(WhatsAppCloudChannel, channel).coexistence_sync["history"]["status"] == "pending"
+        db.execute(update(WhatsAppCoexistenceEvent).values(available_at=now_utc()))
+        db.commit()
+    # A fresh process/session continues from the persisted offset.
+    with TestingSession() as db:
+        asyncio.run(coex.process_pending(db, limit=1, batch_size=1))
+        messages = db.scalars(select(Message).order_by(Message.created_at)).all()
+        assert [m.role for m in messages] == ["user", "assistant"]
+        assert all(m.is_historical for m in messages)
+        conv = db.scalar(select(Conversation))
+        assert conv.status == "resolved" and conv.waiting_since is None
+        assert conv.social_last_inbound_at is None
+        assert db.get(WhatsAppCloudChannel, channel).coexistence_sync["history"]["progress"] == 100
+        assert db.scalar(select(WhatsAppCoexistenceEvent)).payload == {}
+    ai.assert_not_called()
+
+
+def test_phone_reply_pauses_agent_and_duplicate_does_not_take_over_twice(channel):
+    echo = raw("phone-reply", outgoing=True, age=0)
+    echo["to"] = PERSON
+    with TestingSession() as db:
+        receive(db, channel, "smb_message_echoes", value(message_echoes=[echo]))
+        conv = db.scalar(select(Conversation))
+        assert conv.mode == "human" and conv.taken_over_at
+        assert db.scalar(select(Message)).sender_type == "human"
+        conv.mode = "ai"
+        db.commit()
+        receive(db, channel, "smb_message_echoes", value(message_echoes=[echo]))
+        db.refresh(conv)
+        assert conv.mode == "ai"
+        assert len(db.scalars(select(Message)).all()) == 1
+
+
+def test_phone_reply_received_during_generation_suppresses_ai(channel, authenticated_client, monkeypatch):
+    async def complete(*args, **kwargs):
+        echo = raw("person-took-over", outgoing=True, age=0)
+        echo["to"] = PERSON
+        with TestingSession() as other:
+            receive(other, channel, "smb_message_echoes", value(message_echoes=[echo]))
+        return Completion(text="This must not be sent")
+    monkeypatch.setattr(whatsapp_inbound, "run_completion", complete)
+    monkeypatch.setattr(whatsapp_inbound, "_signal_read_and_typing", AsyncMock())
+    send = AsyncMock()
+    monkeypatch.setattr(whatsapp_cloud_webhook, "send_text", send)
+    response = _post_signed(authenticated_client, str(channel), _webhook_payload([raw("new-inbound", age=0)]))
+    assert response.status_code == 200
+    send.assert_not_called()
+    with TestingSession() as db:
+        assert db.scalar(select(Conversation)).mode == "human"
+        assert not db.scalars(select(Message).where(Message.sender_type == "ai")).all()
+
+
+def test_history_does_not_duplicate_live_message_or_overwrite_its_role(channel):
+    echo = raw("same-id", outgoing=True)
+    echo["to"] = PERSON
+    with TestingSession() as db:
+        receive(db, channel, "smb_message_echoes", value(message_echoes=[echo]))
+        receive(db, channel, "history", history(echo))
+        asyncio.run(coex.process_pending(db))
+        message = db.scalar(select(Message))
+        assert not message.is_historical and message.role == "assistant"
+        assert len(db.scalars(select(Message)).all()) == 1
+
+
+def test_other_number_and_forged_signature_are_rejected(channel, authenticated_client):
+    with TestingSession() as db:
+        other = history(raw("wrong-number"))
+        other["metadata"]["phone_number_id"] = "222"
+        assert receive(db, channel, "history", other) is False
+    payload = {"entry": [{"id": "waba-1", "changes": [{"field": "history", "value": history(raw("forged"))}]}]}
+    assert _post_signed(authenticated_client, str(channel), payload, secret="wrong").status_code == 403
+    with TestingSession() as db:
+        assert not db.scalars(select(WhatsAppCoexistenceEvent)).all()
+
+
+def test_history_declined_is_a_supported_choice(channel):
+    with TestingSession() as db:
+        receive(db, channel, "history", value(history=[{"errors": [{"code": 2593109}]}]))
+        asyncio.run(coex.process_pending(db))
+        row = db.get(WhatsAppCloudChannel, channel)
+        assert row.coexistence_sync["history"]["status"] == "declined"
+        assert row.status == "connected"
+
+
+def test_sync_requests_are_once_only_and_store_meta_request_ids(channel, monkeypatch):
+    send = AsyncMock(side_effect=[httpx.Response(200, json={"request_id": "contacts-1"}), httpx.Response(200, json={"request_id": "history-1"})])
+    monkeypatch.setattr(coex, "_graph_request", send)
+    with TestingSession() as db:
+        row = db.get(WhatsAppCloudChannel, channel)
+        asyncio.run(coex.request_sync(db, row))
+        asyncio.run(coex.request_sync(db, row))
+        assert row.coexistence_sync["contacts"]["request_id"] == "contacts-1"
+        assert row.coexistence_sync["history"]["request_id"] == "history-1"
+    assert send.await_count == 2
+    assert send.call_args_list[0].kwargs["json"]["sync_type"] == "smb_app_state_sync"
+
+
+def test_ambiguous_sync_response_is_not_retried(channel, monkeypatch):
+    send = AsyncMock(side_effect=HTTPException(status_code=502))
+    monkeypatch.setattr(coex, "_graph_request", send)
+    with TestingSession() as db:
+        row = db.get(WhatsAppCloudChannel, channel)
+        asyncio.run(coex.request_sync(db, row))
+        asyncio.run(coex.request_sync(db, row))
+        assert row.coexistence_sync["history"]["status"] == "unknown"
+    assert send.await_count == 2
+
+
+def test_media_history_can_arrive_before_the_message(channel, monkeypatch):
+    media = raw("photo", kind="image")
+    media["image"] = {"id": "asset-1", "caption": "A photo"}
+    monkeypatch.setattr(coex, "fetch_media", AsyncMock(return_value=(b"image bytes", "image/jpeg")))
+    with TestingSession() as db:
+        receive(db, channel, "history", value(messages=[media]))
+        asyncio.run(coex.process_pending(db))
+        receive(db, channel, "history", history(raw("photo", kind="media_placeholder")))
+        asyncio.run(coex.process_pending(db))
+        db.execute(update(WhatsAppCoexistenceEvent).values(available_at=now_utc()))
+        db.commit()
+        asyncio.run(coex.process_pending(db))
+        message = db.scalar(select(Message))
+        assert message.content == "A photo" and len(message.attachments) == 1
+        assert message.is_historical
+
+
+def test_offboarding_stops_messages_and_drops_credentials(channel):
+    with TestingSession() as db:
+        receive(db, channel, "account_update", {"event": "PARTNER_REMOVED", "phone_number": BUSINESS})
+        row = db.get(WhatsAppCloudChannel, channel)
+        assert row.status == "disconnected" and not row.is_enabled and not row.encrypted_access_token
+        assert row.coexistence_sync["offboarded_at"]
+
+
+def test_import_query_count_does_not_grow_per_message(channel):
+    with TestingSession() as db:
+        receive(db, channel, "history", history(*[raw(f"history-{i}", age=1000-i) for i in range(100)]))
+        calls = []
+        engine = db.get_bind()
+        def count(*args): calls.append(1)
+        event.listen(engine, "before_cursor_execute", count)
+        try:
+            asyncio.run(coex.process_pending(db, limit=1))
+        finally:
+            event.remove(engine, "before_cursor_execute", count)
+        assert len(calls) < 25, len(calls)
+        assert len(db.scalars(select(Message)).all()) == 100
+
+
+def test_contacts_name_history_placeholders_and_ignore_out_of_order_changes(channel):
+    def contact(action, age, name=""):
+        return {"type": "contact", "action": action, "metadata": {"timestamp": str(int((now_utc()-timedelta(seconds=age)).timestamp()))},
+                "contact": {"phone_number": PERSON, "full_name": name}}
+    with TestingSession() as db:
+        receive(db, channel, "history", history(raw("old-contact")))
+        asyncio.run(coex.process_pending(db))
+        receive(db, channel, "smb_app_state_sync", value(state_sync=[contact("add", 500, "Sam")]))
+        asyncio.run(coex.process_pending(db))
+        db.expire_all()
+        person = db.scalar(select(Contact))
+        assert person.name == "Sam"
+        receive(db, channel, "smb_app_state_sync", value(state_sync=[contact("remove", 100)]))
+        asyncio.run(coex.process_pending(db))
+        receive(db, channel, "smb_app_state_sync", value(state_sync=[contact("add", 300, "Stale name")]))
+        asyncio.run(coex.process_pending(db))
+        db.refresh(person)
+        assert person.name == ""
+        assert len(db.scalars(select(Message)).all()) == 1
+        person.name = "My customer label"
+        db.commit()
+        receive(db, channel, "smb_app_state_sync", value(state_sync=[contact("add", 0, "Phone label")]))
+        asyncio.run(coex.process_pending(db))
+        db.refresh(person)
+        assert person.name == "My customer label"
+
+
+def test_history_does_not_open_the_api_reply_window(channel):
+    with TestingSession() as db:
+        receive(db, channel, "history", history(raw("recent-but-imported", age=30)))
+        asyncio.run(coex.process_pending(db))
+        conv = db.scalar(select(Conversation))
+        conv.status = "open"
+        assert coex.window_fields(conv)["reply_block_reason"] == "reply_window_closed"
+        with pytest.raises(HTTPException):
+            coex.require_reply(conv)
+
+
+def test_restart_does_not_repeat_an_inflight_sync(channel, monkeypatch):
+    send = AsyncMock()
+    monkeypatch.setattr(coex, "_graph_request", send)
+    with TestingSession() as db:
+        row = db.get(WhatsAppCloudChannel, channel)
+        row.coexistence_sync = {part: {"status": "requesting", "requested_at": (now_utc()-timedelta(minutes=10)).isoformat()}
+                                for part in ("history", "contacts")}
+        db.commit()
+        asyncio.run(coex.run_scope(db))
+        assert row.coexistence_sync["history"]["status"] == "unknown"
+    send.assert_not_called()

--- a/apps/api/tests/test_whatsapp_coexistence.py
+++ b/apps/api/tests/test_whatsapp_coexistence.py
@@ -96,6 +96,36 @@ def test_phone_reply_pauses_agent_and_duplicate_does_not_take_over_twice(channel
         assert len(db.scalars(select(Message)).all()) == 1
 
 
+def test_manual_routes_cannot_replace_or_locally_offboard_a_business_app_number(channel, authenticated_client):
+    with TestingSession() as db:
+        stored = db.get(WhatsAppCloudChannel, channel)
+        client_id, agent_id = str(stored.client_id), str(stored.agent_id)
+    url = f"/api/whatsapp-cloud/channels/{client_id}"
+    assert authenticated_client.put(url, json={"agent_id": agent_id, "phone_number_id": "222"}).status_code == 409
+    assert authenticated_client.post(f"{url}/disconnect").status_code == 409
+    assert authenticated_client.put(url, json={"agent_id": agent_id}).status_code == 200
+    with TestingSession() as db:
+        stored = db.get(WhatsAppCloudChannel, channel)
+        stored.is_enabled = False
+        stored.status = "disconnected"
+        db.commit()
+    assert authenticated_client.put(url, json={"agent_id": agent_id}).json()["is_enabled"] is False
+
+
+def test_failed_import_is_visible_and_does_not_erase_accepted_messages(channel, monkeypatch):
+    with TestingSession() as db:
+        receive(db, channel, "history", history(raw("bad-chunk")))
+        db.execute(update(WhatsAppCoexistenceEvent).values(attempts=7))
+        db.commit()
+        def fail(*args, **kwargs):
+            raise ValueError("Invalid import")
+        monkeypatch.setattr(coex, "_messages", fail)
+        asyncio.run(coex.process_pending(db))
+        assert db.get(WhatsAppCloudChannel, channel).coexistence_sync["history"]["status"] == "error"
+        receipt = db.scalar(select(WhatsAppCoexistenceEvent))
+        assert receipt.attempts == 8 and receipt.payload
+
+
 def test_phone_reply_received_during_generation_suppresses_ai(channel, authenticated_client, monkeypatch):
     async def complete(*args, **kwargs):
         echo = raw("person-took-over", outgoing=True, age=0)

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -229,6 +229,13 @@ export type WhatsAppCloudChannel = {
   display_name: string | null;
   phone_number_id: string;
   waba_id: string | null;
+  coexistence: boolean;
+  coexistence_sync: {
+    started_at?: string;
+    offboarded_at?: string;
+    contacts?: { status: string; request_id?: string; error?: string };
+    history?: { status: string; progress?: number; request_id?: string; error?: string };
+  };
   has_access_token: boolean;
   has_app_secret: boolean;
   webhook_url: string;

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -234,6 +234,7 @@ export type WhatsAppCloudChannel = {
     started_at?: string;
     offboarded_at?: string;
     contacts?: { status: string; request_id?: string; error?: string };
+    media?: { status: string; error?: string };
     history?: { status: string; progress?: number; request_id?: string; error?: string };
   };
   has_access_token: boolean;


### PR DESCRIPTION
Receive WhatsApp Business app message echoes and import contacts/history through durable, deduplicated receipts. A phone reply pauses the conversation and suppresses an AI response still being generated; imported chats keep their timestamps and do not trigger replies or open the API messaging window.

Adds the additive 0038 migration, bounded background processing, attachment enrichment, contact update ordering, explicit offboarding handling, and guards against replacing a Business app connection through manual routes.

Validation: full API suite 288 passed, including webhook, takeover, history, media, reply-window, contact, restart and ownership tests. Frontend type checking and production build with the matching consumer also passed.
