### PR TITLE
Support WhatsApp messages with hidden phone numbers

### DIFF
--- a/apps/api/app/routers/whatsapp_cloud_webhook.py
+++ b/apps/api/app/routers/whatsapp_cloud_webhook.py
@@ -14,7 +14,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 from ..database import get_db
@@ -24,6 +24,7 @@ from ..security import decrypt_secret
 from ..services.whatsapp_cloud import fetch_media, send_text
 from ..services.whatsapp_format import markdown_to_whatsapp
 from ..services.whatsapp_inbound import InboundMessage, process_inbound
+from ..services.whatsapp_identity import contact_names, peer_id, resolve_peer_contact, user_id
 
 
 public_router = APIRouter(prefix="/public/whatsapp-cloud", tags=["WhatsApp Cloud public"])
@@ -59,12 +60,13 @@ def verify_webhook(
 def _parse_message(message: dict, contacts: dict[str, str]) -> InboundMessage | None:
     """Map one Cloud API message to the shared inbound shape; None to skip."""
     kind = message.get("type")
-    sender = message.get("from") or ""
+    sender = peer_id(message) or ""
     from ..services.social_inbound import event_time
     base = {
         "external_message_id": message.get("id") or "",
         "external_chat_id": sender,
         "sender_name": contacts.get(sender),
+        "sender_user_id": user_id(message),
         "occurred_at": event_time(message.get("timestamp")),
     }
     if not base["external_message_id"] or not sender:
@@ -90,15 +92,19 @@ def _apply_incoming_reaction(db: Session, channel: WhatsAppCloudChannel, message
     """The customer reacted to a message (or removed the reaction)."""
     reaction = message.get("reaction") or {}
     target_id = reaction.get("message_id")
-    sender = message.get("from") or ""
+    sender = peer_id(message) or ""
     if not target_id or not sender:
         return
+    contact = resolve_peer_contact(db, channel, sender, sender_user_id=user_id(message))
+    peer_filter = Conversation.external_chat_id == sender
+    if contact:
+        peer_filter = or_(peer_filter, Conversation.contact_id == contact.id)
     target = db.scalar(
         select(Message)
         .join(Conversation, Conversation.id == Message.conversation_id)
         .where(
             Conversation.whatsapp_cloud_channel_id == channel.id,
-            Conversation.external_chat_id == sender,
+            peer_filter,
             Message.external_message_id == target_id,
         )
     )
@@ -157,10 +163,7 @@ async def receive_webhook(channel_id: uuid.UUID, request: Request, db: Session =
                 continue
             for status in value.get("statuses") or []:
                 _record_status(db, channel, status)
-            contacts = {
-                contact.get("wa_id"): (contact.get("profile") or {}).get("name")
-                for contact in value.get("contacts") or []
-            }
+            contacts = contact_names(value.get("contacts") or [])
             for raw_message in value.get("messages") or []:
                 if raw_message.get("type") == "reaction":
                     _apply_incoming_reaction(db, channel, raw_message)

--- a/apps/api/app/services/contacts.py
+++ b/apps/api/app/services/contacts.py
@@ -1,8 +1,4 @@
-"""Contacts: the people behind the chats, one record per client and phone.
-
-WhatsApp identifies a person by number, so that is the key. Widget and
-playground conversations carry no number and therefore no contact.
-"""
+"""Contacts and their phone or account-scoped messaging identities."""
 
 from __future__ import annotations
 
@@ -13,6 +9,7 @@ from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from ..models import Contact, ContactIdentity, Conversation, Message, now_utc
+from .whatsapp_identity import is_user_id
 
 
 _NON_DIGITS = re.compile(r"[^0-9]")
@@ -21,6 +18,8 @@ _NON_DIGITS = re.compile(r"[^0-9]")
 def normalize_phone(raw: str | None) -> str | None:
     """Digits only, no plus sign, the way WhatsApp reports numbers. None when
     what is left is too short to be a phone number."""
+    if is_user_id(raw):
+        return None
     digits = _NON_DIGITS.sub("", raw or "")
     return digits if len(digits) >= 7 else None
 

--- a/apps/api/app/services/whatsapp_cloud.py
+++ b/apps/api/app/services/whatsapp_cloud.py
@@ -9,6 +9,7 @@ import httpx
 from fastapi import HTTPException
 
 from ..config import get_settings
+from .whatsapp_identity import recipient_fields
 
 MAX_MEDIA_BYTES = 20 * 1024 * 1024
 # Hard limit of the Cloud API for a text message body.
@@ -61,7 +62,7 @@ async def send_text(
     on the referenced message."""
     payload = {
         "messaging_product": "whatsapp",
-        "to": to,
+        **recipient_fields(to),
         "type": "text",
         "text": {"body": body[:MAX_TEXT_LENGTH]},
     }
@@ -82,7 +83,7 @@ async def send_reaction(access_token: str, phone_number_id: str, to: str, messag
     Raises on failure so the caller decides whether the gesture matters."""
     payload = {
         "messaging_product": "whatsapp",
-        "to": to,
+        **recipient_fields(to),
         "type": "reaction",
         "reaction": {"message_id": message_id, "emoji": emoji},
     }
@@ -158,7 +159,7 @@ async def send_media(
         media_object["caption"] = caption[:1024]
     if filename and kind == "document":
         media_object["filename"] = filename
-    payload = {"messaging_product": "whatsapp", "to": to, "type": kind, kind: media_object}
+    payload = {"messaging_product": "whatsapp", **recipient_fields(to), "type": kind, kind: media_object}
     response = await _graph_request("POST", _graph_url(f"{phone_number_id}/messages"), access_token, json=payload)
     if response.status_code >= 400:
         raise HTTPException(status_code=502, detail=f"WhatsApp could not send the file: {_graph_error(response)}")

--- a/apps/api/app/services/whatsapp_coexistence.py
+++ b/apps/api/app/services/whatsapp_coexistence.py
@@ -22,9 +22,10 @@ from ..database import new_session
 from ..models import Contact, Conversation, Message, WhatsAppCloudChannel, WhatsAppCoexistenceEvent, new_uuid, now_utc
 from ..security import decrypt_secret
 from .attachments import ensure_uploadable, store_attachment
-from .contacts import normalize_phone
+from .contacts import display_name, normalize_phone
 from .social_inbound import event_time
 from .whatsapp_cloud import _graph_request, _graph_url, fetch_media
+from .whatsapp_identity import is_user_id, peer_id, resolve_peer_contact, user_id
 
 logger = logging.getLogger(__name__)
 FIELDS = frozenset({"history", "smb_app_state_sync", "smb_message_echoes", "account_update"})
@@ -92,49 +93,65 @@ def _text(raw):
 
 def _messages(db, channel, rows, *, historical):
     """Bulk lookups keep a large history chunk from issuing queries per message."""
-    rows = [(peer, raw) for peer, raw in rows if normalize_phone(peer) and raw.get("id") and event_time(raw.get("timestamp"))]
+    rows = [(peer, raw) for peer, raw in rows if (normalize_phone(peer) or is_user_id(peer)) and raw.get("id") and event_time(raw.get("timestamp"))]
     if not rows:
         return
     peers = {peer for peer, _ in rows}
-    lock_chats(db, channel.id, peers)
+    business = normalize_phone(channel.phone_number)
+    identities = {}
+    for peer, raw in rows:
+        outgoing = not historical or (business and normalize_phone(raw.get("from")) == business) or peer_id(raw, "to") == peer
+        identity = user_id(raw, "to" if outgoing else "from")
+        if identity:
+            identities[peer] = identity
+    lock_chats(db, channel.id, peers | set(identities.values()))
     existing = {m.external_message_id: m for m in db.scalars(select(Message).join(Conversation).where(
         Conversation.whatsapp_cloud_channel_id == channel.id,
         Message.external_message_id.in_([str(raw["id"]) for _, raw in rows]))).all()}
     contacts = {c.phone: c for c in db.scalars(select(Contact).where(Contact.client_id == channel.client_id, Contact.phone.in_(peers)))}
-    missing = peers - contacts.keys()
+    missing = {peer for peer in peers - contacts.keys() if not is_user_id(peer) and peer not in identities}
     if missing:
         db.execute(insert(Contact).values([dict(id=new_uuid(), client_id=channel.client_id, phone=peer, name="") for peer in missing])
                    .on_conflict_do_nothing(index_elements=["client_id", "phone"], index_where=Contact.phone.is_not(None)))
         contacts = {c.phone: c for c in db.scalars(select(Contact).where(Contact.client_id == channel.client_id, Contact.phone.in_(peers)))}
+    for peer in peers:
+        if is_user_id(peer) or peer in identities:
+            contacts[peer] = resolve_peer_contact(db, channel, peer, sender_user_id=identities.get(peer))
     conversations = db.scalars(select(Conversation).where(Conversation.whatsapp_cloud_channel_id == channel.id,
-        Conversation.external_chat_id.in_(peers)).order_by(Conversation.created_at.desc())).all()
+        or_(Conversation.external_chat_id.in_(peers), Conversation.contact_id.in_([c.id for c in contacts.values()]))
+        ).order_by(Conversation.created_at.desc())).all()
     by_peer = {}
+    by_contact = {}
     for conversation in conversations:
         wanted = conversation.id == uuid.uuid5(channel.id, "history:" + conversation.external_chat_id) if historical else conversation.status != "resolved"
         if wanted:
             by_peer.setdefault(conversation.external_chat_id, conversation)
-    business = normalize_phone(channel.phone_number)
+            if not historical:
+                by_contact.setdefault(conversation.contact_id, conversation)
     for peer, raw in rows:
         mid = str(raw["id"])
         if mid in existing:
             continue
         occurred = event_time(raw["timestamp"])
-        outgoing = not historical or normalize_phone(raw.get("from")) == business or raw.get("to") == peer
+        outgoing = not historical or (business and normalize_phone(raw.get("from")) == business) or peer_id(raw, "to") == peer
         contact = contacts[peer]
-        conversation = by_peer.get(peer)
+        conversation = by_peer.get(peer) or by_contact.get(contact.id)
         if not conversation:
             conversation = Conversation(id=uuid.uuid5(channel.id, "history:" + peer) if historical else new_uuid(),
                 agency_id=channel.agency_id, client_id=channel.client_id, agent_id=channel.agent_id,
                 channel="whatsapp_cloud", whatsapp_cloud_channel_id=channel.id, external_chat_id=peer,
-                title=(contact.name or "+" + peer)[:240], contact_id=contact.id, contact_name=contact.name or None,
+                title=display_name(contact)[:240], contact_id=contact.id, contact_name=contact.name or None,
                 mode="human", status="resolved" if historical else "open", created_at=occurred, updated_at=occurred,
                 resolved_at=occurred if historical else None)
             db.add(conversation)
             by_peer[peer] = conversation
+            if not historical:
+                by_contact[contact.id] = conversation
         if historical:
             conversation.created_at = min(conversation.created_at, occurred)
             conversation.resolved_at = max(conversation.resolved_at or occurred, occurred)
         else:
+            conversation.external_chat_id = peer
             # A retry is deduplicated above, so it cannot take over again after
             # an operator has explicitly returned the conversation to the AI.
             conversation.mode = "human"
@@ -183,7 +200,7 @@ def accept_change(db, channel, field: str, value: dict, *, waba_id: str = "") ->
         return False
     if field == "smb_message_echoes":
         business = normalize_phone(channel.phone_number)
-        rows = [(normalize_phone(raw.get("to")), raw) for raw in value.get("message_echoes", [])
+        rows = [(peer_id(raw, "to"), raw) for raw in value.get("message_echoes", [])
                 if business and normalize_phone(raw.get("from")) == business]
         _messages(db, channel, rows, historical=False)
     else:
@@ -230,7 +247,10 @@ async def request_sync(db, channel):
 def _history_rows(value):
     for batch in value.get("history", []):
         for thread in batch.get("threads", []):
-            peer = normalize_phone(thread.get("id"))
+            context = thread.get("context") or {}
+            peer = normalize_phone(thread.get("id") or context.get("wa_id"))
+            if not peer:
+                peer = next((value for value in (context.get("user_id"), context.get("parent_user_id"), thread.get("id")) if is_user_id(value)), None)
             if peer:
                 for raw in thread.get("messages", []):
                     yield peer, raw

--- a/apps/api/app/services/whatsapp_identity.py
+++ b/apps/api/app/services/whatsapp_identity.py
@@ -1,0 +1,52 @@
+"""Keep Meta's opaque user identifiers distinct from telephone numbers."""
+
+import re
+
+_USER_ID = re.compile(r"[A-Z]{2}\.(?:ENT\.)?[A-Za-z0-9]{1,128}\Z")
+
+
+def is_user_id(value: str | None) -> bool:
+    return isinstance(value, str) and bool(_USER_ID.fullmatch(value))
+
+
+def user_id(message: dict, direction: str = "from") -> str | None:
+    for key in (f"{direction}_user_id", f"{direction}_parent_user_id"):
+        if is_user_id(message.get(key)):
+            return message[key]
+    return None
+
+
+def peer_id(message: dict, direction: str = "from") -> str | None:
+    return message.get(direction) or user_id(message, direction)
+
+
+def recipient_fields(recipient: str) -> dict:
+    # Meta requires `recipient`, not `to`, when the phone number is hidden.
+    return {"recipient" if is_user_id(recipient) else "to": recipient}
+
+
+def contact_names(contacts: list[dict]) -> dict[str, str]:
+    names = {}
+    for contact in contacts:
+        profile = contact.get("profile") or {}
+        name = profile.get("name") or profile.get("username") or contact.get("username")
+        for key in ("wa_id", "user_id", "parent_user_id"):
+            if contact.get(key) and name:
+                names[contact[key]] = name
+    return names
+
+
+def resolve_peer_contact(db, channel, peer: str, *, name=None, sender_user_id=None):
+    from .contacts import find_contact, phone_from_chat_id, resolve_contact
+
+    phone = phone_from_chat_id(peer)
+    identity = sender_user_id or (peer if is_user_id(peer) else None)
+    if identity:
+        contact = resolve_contact(db, channel.client_id, provider="whatsapp",
+            external_account_id=channel.waba_id or channel.phone_number_id or str(channel.id),
+            external_user_id=identity, phone=phone, name=name)
+        if phone and not contact.phone and not find_contact(db, channel.client_id, phone):
+            contact.phone = phone
+            db.flush()
+        return contact
+    return resolve_contact(db, channel.client_id, phone=phone, name=name) if phone else None

--- a/apps/api/app/services/whatsapp_inbound.py
+++ b/apps/api/app/services/whatsapp_inbound.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from ..database import new_session
@@ -36,6 +36,7 @@ from .escalation import (
 )
 from .whatsapp import deliver_reaction, send_channel_message, signal_channel_read
 from .whatsapp_format import parse_reply_directives
+from .whatsapp_identity import resolve_peer_contact
 
 
 @dataclass
@@ -50,6 +51,7 @@ class InboundMessage:
     # External id of the message the visitor replied to (swipe-to-reply).
     quoted_external_id: str | None = None
     occurred_at: datetime | None = None
+    sender_user_id: str | None = None
 
 
 @dataclass
@@ -125,7 +127,7 @@ async def process_inbound(
     """
     if conversation_channel == "whatsapp_cloud" and channel.coexistence:
         from .whatsapp_coexistence import lock_chats
-        lock_chats(db, channel.id, [inbound.external_chat_id])
+        lock_chats(db, channel.id, [peer for peer in (inbound.external_chat_id, inbound.sender_user_id) if peer])
     fk_column = getattr(Conversation, channel_fk_field)
 
     existing = db.scalar(
@@ -139,13 +141,21 @@ async def process_inbound(
     if existing:
         return InboundResult(accepted=False, conversation_id=existing.conversation_id)
 
+    contact = None
+    peer_filter = Conversation.external_chat_id == inbound.external_chat_id
+    if conversation_channel == "whatsapp_cloud":
+        contact = resolve_peer_contact(db, channel, inbound.external_chat_id,
+            name=inbound.sender_name, sender_user_id=inbound.sender_user_id)
+        if contact:
+            peer_filter = or_(peer_filter, Conversation.contact_id == contact.id)
+
     # A message joins the chat's open conversation; once that is resolved the
     # next message starts a new case, so the same chat id can hold many.
     conversation = db.scalar(
         select(Conversation)
         .where(
             fk_column == channel.id,
-            Conversation.external_chat_id == inbound.external_chat_id,
+            peer_filter,
             Conversation.status != "resolved",
         )
         .order_by(Conversation.created_at.desc())
@@ -156,7 +166,7 @@ async def process_inbound(
             contact = resolve_contact(db, channel.client_id, provider=conversation_channel,
                 external_account_id=channel.external_account_id, external_user_id=inbound.external_chat_id,
                 name=inbound.sender_name)
-        else:
+        elif conversation_channel != "whatsapp_cloud":
             phone = phone_from_chat_id(inbound.external_chat_id)
             contact = resolve_contact(db, channel.client_id, phone=phone, name=inbound.sender_name) if phone else None
         if contact:
@@ -182,6 +192,13 @@ async def process_inbound(
         if contact and not contact.name.strip():
             contact.name = inbound.sender_name.strip()[:180]
             rename_conversations(db, contact)
+
+    # The same person can stop sharing their phone number between messages.
+    # Preserve the case and its takeover state while updating the reply address.
+    if conversation_channel == "whatsapp_cloud":
+        conversation.external_chat_id = inbound.external_chat_id
+        if contact:
+            conversation.contact_id = contact.id
 
     display_content, llm_content = await resolve_inbound_content(db, channel.agent, inbound)
     visitor_message = Message(

--- a/apps/api/tests/test_whatsapp_user_identifiers.py
+++ b/apps/api/tests/test_whatsapp_user_identifiers.py
@@ -1,0 +1,138 @@
+"""Messages with hidden phone numbers must still reach the inbox and get replies."""
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from sqlalchemy import select
+
+from app.models import Contact, ContactIdentity, Conversation, Message, WhatsAppCloudChannel, now_utc
+from app.services import whatsapp_cloud, whatsapp_coexistence as coex, whatsapp_inbound
+from app.services.ai import Completion
+from app.services.contacts import normalize_phone
+from app.services.whatsapp_identity import resolve_peer_contact
+from conftest import TestingSession
+from test_whatsapp_cloud import _setup_channel, _post_signed, _webhook_payload
+
+BSUID = "CO.123456789012345Ab"
+PHONE = "573001112233"
+BUSINESS = "573009998877"
+
+
+def incoming(mid, identity=BSUID, phone=None):
+    return {"id": mid, "from_user_id": identity, **({"from": phone} if phone else {}),
+        "timestamp": str(int(now_utc().timestamp())), "type": "text", "text": {"body": "Hello"}}
+
+
+def setup(client, monkeypatch):
+    customer, agent, channel = _setup_channel(client)
+    completion = AsyncMock(return_value=Completion(text="Welcome!"))
+    monkeypatch.setattr(whatsapp_inbound, "run_completion", completion)
+    graph = AsyncMock(return_value=httpx.Response(200, json={"messages": [{"id": "wamid.reply"}]}))
+    monkeypatch.setattr(whatsapp_cloud, "_graph_request", graph)
+    monkeypatch.setattr(whatsapp_inbound, "notify_needs_human", AsyncMock())
+    with TestingSession() as db:
+        stored = db.get(WhatsAppCloudChannel, uuid.UUID(channel["id"]))
+        stored.coexistence = True
+        stored.status = "connected"
+        stored.phone_number = BUSINESS
+        db.commit()
+    return channel, completion, graph
+
+
+@pytest.mark.parametrize("identity,field", [(BSUID, "from_user_id"), ("CO.ENT.123456789012345Ab", "from_parent_user_id")])
+def test_hidden_phone_receives_replies_and_deduplicates(authenticated_client, monkeypatch, identity, field):
+    channel, completion, graph = setup(authenticated_client, monkeypatch)
+    message = incoming("wamid.hidden", identity)
+    message[field] = message.pop("from_user_id")
+    contacts = [{"user_id" if field == "from_user_id" else "parent_user_id": identity, "profile": {"name": "Maria"}}]
+    payload = _webhook_payload([message], contacts=contacts)
+    assert _post_signed(authenticated_client, channel["id"], payload).status_code == 200
+    assert _post_signed(authenticated_client, channel["id"], payload).status_code == 200
+    assert completion.await_count == 1
+    sent = [call.kwargs["json"] for call in graph.await_args_list if call.kwargs.get("json", {}).get("type") == "text"]
+    assert len(sent) == 1 and sent[0]["recipient"] == identity and "to" not in sent[0]
+    with TestingSession() as db:
+        conv = db.scalar(select(Conversation))
+        assert conv.external_chat_id == identity and conv.contact_name == "Maria"
+        assert conv.contact.phone is None
+        assert db.scalar(select(ContactIdentity)).external_user_id == identity
+        messages = db.scalars(select(Message).order_by(Message.created_at)).all()
+        assert [m.sender_type for m in messages] == ["visitor", "ai"]
+        assert messages[-1].external_message_id == "wamid.reply"
+
+
+@pytest.mark.parametrize("phone_first", [True, False])
+def test_identity_transitions_preserve_case_and_phone_takeover(authenticated_client, monkeypatch, phone_first):
+    channel, completion, graph = setup(authenticated_client, monkeypatch)
+    for index, phone in enumerate(([PHONE, None] if phone_first else [None, PHONE])):
+        payload = _webhook_payload([incoming(f"wamid.in-{index}", phone=phone)])
+        assert _post_signed(authenticated_client, channel["id"], payload).status_code == 200
+    with TestingSession() as db:
+        assert len(db.scalars(select(Contact)).all()) == 1
+        conv = db.scalar(select(Conversation))
+        assert conv.contact.phone == PHONE
+        assert len(db.scalars(select(Conversation)).all()) == 1
+        conv_id = conv.id
+        echo = {"id": "wamid.phone", "from": BUSINESS, "to_user_id": BSUID,
+            "timestamp": str(int(now_utc().timestamp())), "type": "text", "text": {"body": "I will help"}}
+        stored = db.get(WhatsAppCloudChannel, uuid.UUID(channel["id"]))
+        body = {"metadata": {"phone_number_id": "111"}, "message_echoes": [echo]}
+        assert coex.accept_change(db, stored, "smb_message_echoes", body)
+        db.refresh(conv)
+        assert conv.external_chat_id == BSUID and conv.mode == "human"
+        assert len(db.scalars(select(Conversation)).all()) == 1
+    assert _post_signed(authenticated_client, channel["id"], _webhook_payload([incoming("wamid.after-takeover")])).status_code == 200
+    assert completion.await_count == 2
+    with TestingSession() as db:
+        conv = db.get(Conversation, conv_id)
+        assert conv.mode == "human"
+        assert db.scalar(select(Message).where(Message.external_message_id == "wamid.phone")).sender_type == "human"
+        assert db.scalar(select(Message).where(Message.external_message_id == "wamid.after-takeover")).conversation_id == conv_id
+
+
+@pytest.mark.parametrize("recipient", [BSUID, "CO.ENT.123456789012345Ab", PHONE])
+def test_all_outbound_types_use_the_correct_address_field(monkeypatch, recipient):
+    graph = AsyncMock(return_value=httpx.Response(200, json={"messages": [{"id": "out"}]}))
+    monkeypatch.setattr(whatsapp_cloud, "_graph_request", graph)
+    asyncio.run(whatsapp_cloud.send_text("token", "111", recipient, "Hello"))
+    asyncio.run(whatsapp_cloud.send_reaction("token", "111", recipient, "wamid.in", "👍"))
+    asyncio.run(whatsapp_cloud.send_media("token", "111", recipient, "image", "media-1"))
+    key = "to" if recipient == PHONE else "recipient"
+    other = "recipient" if key == "to" else "to"
+    assert graph.await_count == 3
+    for call in graph.await_args_list:
+        payload = call.kwargs["json"]
+        assert payload[key] == recipient and other not in payload
+    if recipient != PHONE:
+        assert normalize_phone(recipient) is None
+
+
+def test_same_user_id_is_scoped_to_client_and_account(authenticated_client):
+    _, _, data = _setup_channel(authenticated_client)
+    with TestingSession() as db:
+        channel = db.get(WhatsAppCloudChannel, uuid.UUID(data["id"]))
+        first = resolve_peer_contact(db, channel, BSUID)
+        channel.waba_id = "another-account"
+        second = resolve_peer_contact(db, channel, BSUID)
+        assert first.id != second.id
+        assert first.phone is None and second.phone is None
+
+
+def test_history_with_hidden_phone_is_imported_without_reply(authenticated_client, monkeypatch):
+    channel, completion, graph = setup(authenticated_client, monkeypatch)
+    body = {"metadata": {"phone_number_id": "111"}, "history": [{"threads": [
+        {"context": {"user_id": BSUID}, "messages": [incoming("wamid.history")]}
+    ]}]}
+    with TestingSession() as db:
+        stored = db.get(WhatsAppCloudChannel, uuid.UUID(channel["id"]))
+        assert coex.accept_change(db, stored, "history", body)
+        asyncio.run(coex.process_pending(db))
+        message = db.scalar(select(Message))
+        assert message and message.is_historical and message.sender_type == "visitor"
+        assert message.conversation.contact.phone is None
+        assert message.conversation.status == "resolved"
+    completion.assert_not_awaited()
+    graph.assert_not_awaited()


### PR DESCRIPTION
Messages identified by Meta user IDs were discarded when the sender phone field was absent. Preserve account-scoped contacts and conversations, send replies using recipient, and handle Business app echoes and history with hidden phone numbers. Validation: all 297 backend tests passed, including nine new regressions for reception, deduplication, phone visibility changes, human takeover, outbound addressing, account isolation, and history import. No schema changes.