### PR TITLE
Show inbox search with channel and tray filters in one row

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -822,20 +822,12 @@ textarea { line-height: 1.55; }
 .team-member.away i { background: #c2c9d4; }
 .team-channel-options { display: flex; gap: 14px; flex-wrap: wrap; }
 .mini-badge.team { color: #4a5568; border-color: #d7dce4; background: #eef1f5; }
-.inbox-filters { margin: 0 12px 10px; }
-.inbox-filters-toggle { display: flex; align-items: center; gap: 7px; width: 100%; min-height: 34px; padding: 0 10px; border: 1px solid var(--line); border-radius: 8px; background: white; color: #687082; font-size: 13px; font-weight: 500; }
-.inbox-filters-toggle:hover { background: #f7f8fa; }
-.inbox-filters-toggle.has-active { border-color: var(--purple); color: var(--ink); }
-.inbox-filters-toggle em { font-style: normal; min-width: 18px; height: 18px; padding: 0 5px; display: inline-grid; place-items: center; font-size: 11px; font-weight: 600; color: white; background: var(--purple); border-radius: 20px; }
-.inbox-filters-caret { flex-shrink: 0; margin-left: auto; transition: transform .15s; }
-.inbox-filters-toggle[aria-expanded="true"] .inbox-filters-caret { transform: rotate(180deg); }
-.inbox-filters-panel { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; padding: 11px; border: 1px solid var(--line); border-radius: 8px; background: white; }
-.inbox-filters-panel label { flex: 1; min-width: 0; display: flex; align-items: center; gap: 6px; padding: 0 6px 0 9px; min-height: 33px; border: 1px solid var(--line); border-radius: 7px; background: white; color: #687082; }
-.inbox-filters-panel label:focus-within { border-color: var(--purple); }
-.inbox-filters-panel label svg { flex-shrink: 0; }
-.inbox-filters-panel select { flex: 1; min-width: 0; border: none; background: transparent; padding: 0; font-size: 12.5px; color: var(--ink); outline: none; }
-.inbox-filters-panel select:focus, .inbox-filters-panel select:focus-visible { border: none; outline: none; box-shadow: none; }
-.inbox-filters-panel .text-button { flex-basis: 100%; justify-self: start; font-size: 12px; }
+.inbox-filter-row { display: flex; gap: 8px; margin: 10px 12px 2px; }
+.inbox-mini-select { flex: 1; min-width: 0; display: flex; align-items: center; gap: 6px; height: 34px; padding: 0 6px 0 10px; border: 1px solid var(--line); border-radius: 8px; background: white; color: var(--muted); }
+.inbox-mini-select:focus-within { border-color: var(--purple); }
+.inbox-mini-select svg { flex-shrink: 0; }
+.inbox-mini-select select { flex: 1; min-width: 0; border: 0; background: transparent; padding: 0; font-size: 12.5px; color: var(--ink); outline: none; }
+.inbox-mini-select select:focus, .inbox-mini-select select:focus-visible { border: 0; outline: none; box-shadow: none; }
 .availability-toggle { display: flex; align-items: center; gap: 9px; padding: 8px 12px; text-align: left; border: 1px solid var(--line); border-radius: 8px; background: white; font-size: 13px; cursor: pointer; }
 /* The chip anchors the bottom group: its auto margin absorbs the free
  * space, so the language switcher's must not, or the space splits and the

--- a/apps/web/app/portal/[slug]/page.tsx
+++ b/apps/web/app/portal/[slug]/page.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
-import { Archive, ArchiveRestore, ArrowLeft, BadgeCheck, Ban, BarChart3, Bot, Building2, CheckCircle2, CheckSquare, ChevronDown, Clock, Contact as ContactIcon, FileText, Filter, FlaskConical, Globe, Images, Inbox, LoaderCircle, LogOut, MessageCircle, MessageSquareText, Reply, Search, Send, ShieldCheck, SmilePlus, Square, Trash2, UserRound, Users, X } from "lucide-react";
+import { Archive, ArchiveRestore, ArrowLeft, BadgeCheck, Ban, BarChart3, Bot, Building2, CheckCircle2, CheckSquare, Clock, Contact as ContactIcon, FileText, FlaskConical, Globe, Images, Inbox, LoaderCircle, LogOut, MessageCircle, MessageSquareText, Reply, Search, Send, ShieldCheck, SmilePlus, Square, Trash2, UserRound, Users, X } from "lucide-react";
 import { useCannedReplies } from "./canned";
 import { ContactsView } from "./contacts";
 import { TeamsView } from "./teams";
@@ -160,7 +160,6 @@ function PortalInbox({ slug, portal, session, logout }: { slug: string; portal: 
   const [search, setSearch] = useState("");
   const [query, setQuery] = useState("");
   const [channelFilter, setChannelFilter] = useState("");
-  const [filtersOpen, setFiltersOpen] = useState(false);
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -403,6 +402,10 @@ function PortalInbox({ slug, portal, session, logout }: { slug: string; portal: 
   );
   return <main className="portal-app" style={{ "--portal-color": portal.agency_brand_color } as React.CSSProperties}><aside className="portal-nav"><div className="portal-brand">{portal.client_logo_url || portal.agency_logo_url ? <img src={`${portal.client_logo_url || portal.agency_logo_url}`} alt="Logo" /> : <span>{portal.client_name.slice(0, 1)}</span>}<strong>{portal.client_name}</strong></div><nav><a className={view === "inbox" ? "active" : ""} onClick={() => setView("inbox")}><Inbox size={18} /> {t("portal.inbox.nav.inbox")}{summary && summary.unread > 0 && view !== "inbox" && <em className="nav-count">{summary.unread}</em>}</a><a className={view === "contacts" ? "active" : ""} onClick={() => setView("contacts")}><ContactIcon size={18} /> {t("portal.inbox.nav.contacts")}</a><a className={view === "teams" ? "active" : ""} onClick={() => setView("teams")}><Users size={18} /> {t("portal.inbox.nav.teams")}</a><a className={view === "templates" ? "active" : ""} onClick={() => setView("templates")}><FileText size={18} /> {t("portal.inbox.nav.templates")}</a><a className={view === "reports" ? "active" : ""} onClick={() => setView("reports")}><BarChart3 size={18} /> {t("portal.inbox.nav.reports")}</a><a className="disabled"><Bot size={18} /> {t("portal.inbox.nav.agents")}</a></nav>{session.user_id && <button className={`availability-toggle ${availability}`} onClick={toggleAvailability} title={t("portal.availability.hint")}><i /><span className="availability-name"><strong>{session.user_name}</strong><small>{availability === "online" ? t("portal.availability.online") : t("portal.availability.away")}</small></span></button>}<LanguageSwitcher /><button onClick={logout}><LogOut size={17} /> {t("portal.inbox.nav.logout")}</button></aside><section className="portal-main"><header><div><small>{t("portal.inbox.header.eyebrow")}</small><h1>{view === "contacts" ? t("portal.inbox.nav.contacts") : view === "teams" ? t("portal.inbox.nav.teams") : view === "templates" ? t("portal.inbox.nav.templates") : view === "reports" ? t("portal.inbox.nav.reports") : portal.portal_title}</h1></div>{view === "inbox" && <span>{t("portal.inbox.header.conversationsCount", { count: items.length })}</span>}</header>{view === "templates" ? <TemplatesView slug={slug} supported={templatesSupported} /> : view === "reports" ? <ReportsView slug={slug} /> : view === "teams" ? <TeamsView slug={slug} /> : view === "contacts" ? <ContactsView slug={slug} channels={channels} openConversation={openFromContact} /> : <div className="portal-inbox"><aside onScroll={onListScroll}>
       <div className="inbox-search"><Search size={16} /><input value={search} onChange={(e) => setSearch(e.target.value)} placeholder={t("inbox.searchPlaceholder")} /></div>
+      {status !== "archived" && <div className="inbox-filter-row">
+        <label className="inbox-mini-select" title={t("inbox.filterChannel")}><MessageCircle size={14} /><select aria-label={t("inbox.filterChannel")} value={channelFilter} onChange={(event) => { setChannelFilter(event.target.value); setSelected(null); }}><option value="">{t("inbox.allChannels")}</option>{INBOX_CHANNELS.filter((value) => value !== "playground").map((value) => <option key={value} value={value}>{channelLabel(value)}</option>)}</select></label>
+        {teams.length > 0 && <label className="inbox-mini-select" title={t("portal.inbox.nav.teams")}><Users size={14} /><select aria-label={t("portal.inbox.nav.teams")} value={teamFilter} onChange={(e) => setTeamFilter(e.target.value)}><option value="">{t("portal.teams.filterAll")}</option>{teams.map((team) => <option key={team.id} value={team.id}>{team.name}{team.unassigned_count > 0 ? ` (${team.unassigned_count})` : ""}</option>)}</select></label>}
+      </div>}
       {status === "archived" ? <div className="archive-head">
         <button type="button" className="text-button" onClick={() => switchStatus("open")}><ArrowLeft size={14} /> {t("portal.inbox.archive.back")}</button>
         <strong><Archive size={14} /> {t("portal.inbox.status.archived")}{summary ? ` · ${summary.archived}` : ""}</strong>
@@ -411,14 +414,6 @@ function PortalInbox({ slug, portal, session, logout }: { slug: string; portal: 
           <button type="button" className="text-button danger-text" disabled={picked.length === 0} onClick={() => { setConfirmWord(""); setDeleting("picked"); }}><Trash2 size={14} /> {t("portal.inbox.archive.deletePicked", { count: String(picked.length) })}</button>
         </div>}
       </div> : <>
-        {(() => { const activeFilters = (channelFilter ? 1 : 0) + (teamFilter ? 1 : 0); return <div className="inbox-filters">
-          <button type="button" className={`inbox-filters-toggle${activeFilters ? " has-active" : ""}`} aria-expanded={filtersOpen} onClick={() => setFiltersOpen((open) => !open)}><Filter size={14} /> {t("portal.inbox.filters.label")}{activeFilters > 0 && <em>{activeFilters}</em>}<ChevronDown size={14} className="inbox-filters-caret" /></button>
-          {filtersOpen && <div className="inbox-filters-panel">
-            <label title={t("inbox.filterChannel")}><MessageCircle size={14} /><select aria-label={t("inbox.filterChannel")} value={channelFilter} onChange={(event) => { setChannelFilter(event.target.value); setSelected(null); }}><option value="">{t("inbox.allChannels")}</option>{INBOX_CHANNELS.filter((value) => value !== "playground").map((value) => <option key={value} value={value}>{channelLabel(value)}</option>)}</select></label>
-            {teams.length > 0 && <label title={t("portal.inbox.nav.teams")}><Users size={14} /><select aria-label={t("portal.inbox.nav.teams")} value={teamFilter} onChange={(e) => setTeamFilter(e.target.value)}><option value="">{t("portal.teams.filterAll")}</option>{teams.map((team) => <option key={team.id} value={team.id}>{team.name}{team.unassigned_count > 0 ? ` (${team.unassigned_count})` : ""}</option>)}</select></label>}
-            {activeFilters > 0 && <button type="button" className="text-button" onClick={() => { setChannelFilter(""); setTeamFilter(""); setSelected(null); }}>{t("portal.inbox.filters.clear")}</button>}
-          </div>}
-        </div>; })()}
         <div className="inbox-switch"><div className="segmented" role="tablist" aria-label={t("portal.inbox.status.open") + " / " + t("portal.inbox.status.resolved")}>
           <button role="tab" aria-selected={status === "open"} className={status === "open" ? "active" : ""} onClick={() => switchStatus("open")}><Inbox size={14} /> {t("portal.inbox.status.open")}</button>
           <button role="tab" aria-selected={status === "resolved"} className={status === "resolved" ? "active" : ""} onClick={() => switchStatus("resolved")}><CheckCircle2 size={14} /> {t("portal.inbox.status.resolved")}</button>


### PR DESCRIPTION
Replace the collapsible Filters toggle in the client portal inbox with the search field and both filters shown together.

## Changes
- The search field keeps its own icon and placeholder, clean and full width.
- Channel and tray filters sit in one compact row directly below the search, each with an icon.
- The tray filter only renders when the client has teams; the channel filter always shows.
- Removes the Filters toggle button, its panel, and the now-unused state and imports.

UI-only, no API route or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)