### PR TITLE
Reconcile WhatsApp Business app disconnection status

### DIFF
--- a/apps/api/app/routers/whatsapp_cloud.py
+++ b/apps/api/app/routers/whatsapp_cloud.py
@@ -60,6 +60,16 @@ def get_channel(client_id: uuid.UUID, db: Session = Depends(get_db), user: User 
     return _public_channel(_channel_for_user(db, user, client_id))
 
 
+@router.post("/channels/{client_id}/refresh", response_model=WhatsAppCloudChannelOut)
+async def refresh_channel(client_id: uuid.UUID, db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    from ..services.whatsapp_coexistence import refresh_connection
+
+    channel = _channel_for_user(db, user, client_id)
+    await refresh_connection(db, channel)
+    db.refresh(channel)
+    return _public_channel(channel)
+
+
 @router.put("/channels/{client_id}", response_model=WhatsAppCloudChannelOut)
 def configure_channel(
     client_id: uuid.UUID,

--- a/apps/api/app/services/whatsapp_coexistence.py
+++ b/apps/api/app/services/whatsapp_coexistence.py
@@ -177,23 +177,82 @@ def _messages(db, channel, rows, *, historical):
             _enqueue(db, channel, "media", {"message_id": str(raw["id"]), "raw": raw})
 
 
+def account_event_waba_id(value: dict, entry_id: str) -> str:
+    """Partner events can identify the affected WABA inside waba_info."""
+    info = value.get("waba_info") or {}
+    return str(info.get("waba_id") or entry_id or "") if isinstance(info, dict) else ""
+
+
+def mark_disconnected(channel, *, offboarded: bool, message: str):
+    channel.status = "disconnected"
+    channel.is_enabled = False
+    channel.encrypted_access_token = None
+    channel.last_error = message
+    channel.updated_at = now_utc()
+    # Lost access alone does not prove a new one-shot history import is allowed.
+    key = "offboarded_at" if offboarded else "authorization_lost_at"
+    channel.coexistence_sync = {**(channel.coexistence_sync or {}), key: now_utc().isoformat()}
+
+
+async def refresh_connection(db, channel):
+    """Reconcile with Meta without registering, disconnecting, or sending anything."""
+    if not channel.coexistence:
+        raise HTTPException(status_code=409, detail="Status refresh is available for WhatsApp Business app connections.")
+    if not channel.encrypted_access_token or not channel.phone_number_id:
+        if channel.is_enabled or channel.status == "connected":
+            mark_disconnected(channel, offboarded=False, message="WhatsApp authorization is missing. Connect the account again.")
+            db.commit()
+        return
+    channel_id = channel.id
+    expected = (channel.phone_number_id, channel.encrypted_access_token, channel.last_connected_at)
+    access_token = decrypt_secret(channel.encrypted_access_token)
+    db.rollback()
+    response = await _graph_request("GET", _graph_url(expected[0]), access_token,
+        params={"fields": "id,is_on_biz_app,platform_type"})
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail="Meta returned an invalid status response. Try again.") from exc
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=502, detail="Meta returned an invalid status response. Try again.")
+    error = data.get("error") or {}
+    if not isinstance(error, dict):
+        raise HTTPException(status_code=502, detail="Meta returned an invalid status response. Try again.")
+    inaccessible = 400 <= response.status_code < 500 and (
+        error.get("code") == 190 or (error.get("code") == 100 and error.get("error_subcode") == 33))
+    if response.status_code >= 400 and not inaccessible:
+        raise HTTPException(status_code=502, detail="Meta could not confirm the connection status. Try again.")
+    if not inaccessible and (str(data.get("id")) != expected[0]
+            or not isinstance(data.get("is_on_biz_app"), bool) or not data.get("platform_type")):
+        raise HTTPException(status_code=502, detail="Meta did not return a complete connection status. Try again.")
+    current = db.scalar(select(WhatsAppCloudChannel).where(WhatsAppCloudChannel.id == channel_id)
+                        .with_for_update().execution_options(populate_existing=True))
+    # A refresh that started before a reconnection must not invalidate its token.
+    if not current or (current.phone_number_id, current.encrypted_access_token, current.last_connected_at) != expected:
+        return
+    if inaccessible:
+        mark_disconnected(current, offboarded=False, message="WhatsApp authorization is no longer available. Connect the account again.")
+    elif not data["is_on_biz_app"] or data["platform_type"] != "CLOUD_API":
+        mark_disconnected(current, offboarded=True, message="WhatsApp Business disconnected this number. Connect it again to resume.")
+    current.coexistence_sync = {**(current.coexistence_sync or {}), "status_checked_at": now_utc().isoformat()}
+    db.commit()
+
+
 def accept_change(db, channel, field: str, value: dict, *, waba_id: str = "") -> bool:
     """Caller must verify the signature. Failure to commit must cause a retry."""
     if field not in FIELDS or not channel.coexistence:
         return False
     delivered = (value.get("metadata") or {}).get("phone_number_id")
     if field == "account_update":
+        waba_id = account_event_waba_id(value, waba_id)
         if not waba_id or waba_id != channel.waba_id:
             return False
         phone = normalize_phone(value.get("phone_number"))
         if phone and phone != normalize_phone(channel.phone_number):
             return False
         if value.get("event") in {"PARTNER_REMOVED", "ACCOUNT_OFFBOARDED"}:
-            channel.status = "disconnected"
-            channel.is_enabled = False
-            channel.encrypted_access_token = None
-            channel.last_error = "WhatsApp Business disconnected this number. Connect it again to resume."
-            channel.coexistence_sync = {**(channel.coexistence_sync or {}), "offboarded_at": now_utc().isoformat()}
+            mark_disconnected(channel, offboarded=True,
+                message="WhatsApp Business disconnected this number. Connect it again to resume.")
         db.commit()
         return True
     if delivered != channel.phone_number_id or not channel.is_enabled:

--- a/apps/api/tests/test_whatsapp_coexistence.py
+++ b/apps/api/tests/test_whatsapp_coexistence.py
@@ -226,6 +226,121 @@ def test_offboarding_stops_messages_and_drops_credentials(channel):
         assert row.coexistence_sync["offboarded_at"]
 
 
+@pytest.mark.parametrize("event_name", ["PARTNER_REMOVED", "ACCOUNT_OFFBOARDED"])
+def test_nested_waba_identifies_offboarding_target(channel, event_name):
+    with TestingSession() as db:
+        row = db.get(WhatsAppCloudChannel, channel)
+        body = {"event": event_name, "waba_info": {"waba_id": "other-waba"}}
+        assert not coex.accept_change(db, row, "account_update", body, waba_id="waba-1")
+        assert row.status == "connected" and row.encrypted_access_token
+        body["waba_info"]["waba_id"] = "waba-1"
+        assert coex.accept_change(db, row, "account_update", body, waba_id="partner-event-id")
+        assert row.status == "disconnected" and not row.encrypted_access_token
+        assert row.coexistence_sync["offboarded_at"]
+
+
+def refresh_url(channel):
+    with TestingSession() as db:
+        return f"/api/whatsapp-cloud/channels/{db.get(WhatsAppCloudChannel, channel).client_id}/refresh"
+
+
+@pytest.mark.parametrize("meta_error", [{"code": 100, "error_subcode": 33}, {"code": 190}])
+def test_refresh_reconciles_revoked_access_and_preserves_history(channel, authenticated_client, monkeypatch, meta_error):
+    with TestingSession() as db:
+        row = db.get(WhatsAppCloudChannel, channel)
+        row.coexistence_sync = {"history": {"status": "declined"}, "contacts": {"status": "complete"}}
+        echo = {**raw("existing-reply", outgoing=True), "to": PERSON}
+        receive(db, channel, "smb_message_echoes", value(message_echoes=[echo]))
+        agent_id = str(row.agent_id)
+    graph = AsyncMock(return_value=httpx.Response(400, json={"error": meta_error}))
+    monkeypatch.setattr(coex, "_graph_request", graph)
+    response = authenticated_client.post(refresh_url(channel))
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["status"] == "disconnected" and not data["is_enabled"] and not data["has_access_token"]
+    assert data["agent_id"] == agent_id
+    assert data["coexistence_sync"]["history"]["status"] == "declined"
+    assert data["coexistence_sync"]["authorization_lost_at"]
+    assert data["coexistence_sync"]["status_checked_at"]
+    assert "offboarded_at" not in data["coexistence_sync"]
+    graph.assert_awaited_once()
+    assert graph.call_args.args[0] == "GET"
+    with TestingSession() as db:
+        assert db.scalar(select(Message)).content == "existing-reply"
+        assert db.scalar(select(Conversation)).mode == "human"
+    assert authenticated_client.post(refresh_url(channel)).status_code == 200
+    graph.assert_awaited_once()
+
+
+@pytest.mark.parametrize("on_app,platform,expected_status", [
+    (True, "CLOUD_API", "connected"), (False, "CLOUD_API", "disconnected"), (True, "NOT_APPLICABLE", "disconnected")])
+def test_refresh_checks_business_app_registration(channel, authenticated_client, monkeypatch, on_app, platform, expected_status):
+    graph = AsyncMock(return_value=httpx.Response(200, json={"id": "111", "is_on_biz_app": on_app, "platform_type": platform}))
+    monkeypatch.setattr(coex, "_graph_request", graph)
+    response = authenticated_client.post(refresh_url(channel))
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == expected_status
+    assert response.json()["coexistence_sync"]["status_checked_at"]
+    if expected_status == "disconnected":
+        assert response.json()["coexistence_sync"]["offboarded_at"]
+    else:
+        assert response.json()["has_access_token"]
+
+
+@pytest.mark.parametrize("response", [
+    httpx.Response(503, json={"error": {"code": 2}}),
+    httpx.Response(400, json={"error": {"code": 4}}),
+    httpx.Response(200, json={"id": "111"}),
+    httpx.Response(200, json={"id": "different-number", "is_on_biz_app": True, "platform_type": "CLOUD_API"}),
+    httpx.Response(200, json=[]), httpx.Response(500, json={"error": "unexpected"}),
+    httpx.Response(502, text="Bad Gateway"),
+])
+def test_uncertain_meta_status_never_revokes_credentials(channel, authenticated_client, monkeypatch, response):
+    monkeypatch.setattr(coex, "_graph_request", AsyncMock(return_value=response))
+    result = authenticated_client.post(refresh_url(channel))
+    assert result.status_code == 502, result.text
+    with TestingSession() as db:
+        row = db.get(WhatsAppCloudChannel, channel)
+        assert row.status == "connected" and row.is_enabled and row.encrypted_access_token
+        assert "status_checked_at" not in row.coexistence_sync
+
+
+def test_refresh_network_failure_keeps_connection(channel, authenticated_client, monkeypatch):
+    monkeypatch.setattr(coex, "_graph_request", AsyncMock(side_effect=HTTPException(502, "Could not reach the Meta API.")))
+    assert authenticated_client.post(refresh_url(channel)).status_code == 502
+    with TestingSession() as db:
+        row = db.get(WhatsAppCloudChannel, channel)
+        assert row.status == "connected" and row.encrypted_access_token
+
+
+def test_late_refresh_cannot_disconnect_a_new_authorization(channel, authenticated_client, monkeypatch):
+    from app.security import encrypt_secret, decrypt_secret
+    async def reconnect(*args, **kwargs):
+        with TestingSession() as db:
+            row = db.get(WhatsAppCloudChannel, channel)
+            row.encrypted_access_token = encrypt_secret("new-authorization")
+            row.last_connected_at = now_utc()
+            db.commit()
+        return httpx.Response(400, json={"error": {"code": 190}})
+    monkeypatch.setattr(coex, "_graph_request", reconnect)
+    response = authenticated_client.post(refresh_url(channel))
+    assert response.status_code == 200 and response.json()["status"] == "connected"
+    with TestingSession() as db:
+        assert decrypt_secret(db.get(WhatsAppCloudChannel, channel).encrypted_access_token) == "new-authorization"
+
+
+def test_refresh_requires_ownership_and_coexistence(channel, authenticated_client, monkeypatch):
+    graph = AsyncMock()
+    monkeypatch.setattr(coex, "_graph_request", graph)
+    assert authenticated_client.post(f"/api/whatsapp-cloud/channels/{uuid.uuid4()}/refresh").status_code == 404
+    with TestingSession() as db:
+        row = db.get(WhatsAppCloudChannel, channel)
+        row.coexistence = False
+        db.commit()
+    assert authenticated_client.post(refresh_url(channel)).status_code == 409
+    graph.assert_not_called()
+
+
 def test_import_query_count_does_not_grow_per_message(channel):
     with TestingSession() as db:
         receive(db, channel, "history", history(*[raw(f"history-{i}", age=1000-i) for i in range(100)]))


### PR DESCRIPTION
Disconnecting a WhatsApp Business app number could leave the integration marked connected. Add an authenticated status refresh that checks Meta, safely clears unusable credentials, and preserves conversation history and the assigned agent.

Handle account update events whose affected WABA is nested in `waba_info`, including when it differs from the envelope identifier. Reject uncertain provider responses without changing a valid connection, and protect a fresh authorization from a late refresh response.

Validation: all 314 API tests passed, including revoked access, transient errors, nested event routing, history preservation, and a concurrent reauthorization.
