### PR TITLE
docs: document Docker quickstart host prerequisites

### DIFF
--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -6,7 +6,26 @@ OpenLivery runs as three services plus PostgreSQL, orchestrated by Docker Compos
 
 ## Requirements
 
-You need [Docker](https://docs.docker.com/get-docker/) — Docker Desktop, or Docker Engine with the Compose plugin. Nothing else is installed on the host; every service (frontend, backend, WhatsApp bridge and database) runs in a container.
+You need the following tools on the host:
+
+- [Docker](https://docs.docker.com/get-docker/) — Docker Desktop, or Docker Engine with the Compose plugin.
+- Git, GNU Make, a POSIX-compatible shell and OpenSSL.
+
+The commands in this guide are written for a POSIX-compatible shell. On Windows,
+run them from WSL or Git Bash rather than PowerShell. Python, Node.js, Go and
+PostgreSQL run inside the containers and do not need to be installed on the host
+for this setup.
+
+Check the prerequisites before continuing:
+
+```bash
+git --version
+docker --version
+docker compose version
+make --version
+sh -c 'echo POSIX shell: $0'
+openssl version
+```
 
 ## Install and run
 

--- a/docs/en/self-hosting.md
+++ b/docs/en/self-hosting.md
@@ -51,16 +51,26 @@ front of it (see [Go to production](#go-to-production-https)). One instance =
 
 ## Before you begin
 
-You need a host with Docker:
+You need the following tools on the host:
 
 - macOS / Windows — [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 - Linux / a server — Docker Engine with the Compose plugin.
+- Git, GNU Make, a POSIX-compatible shell and OpenSSL.
 
-Check it is running:
+The commands in this guide are written for a POSIX-compatible shell. On Windows,
+run them from WSL or Git Bash rather than PowerShell. Python, Node.js, Go and
+PostgreSQL run inside the containers and do not need to be installed on the host
+for this installation path.
+
+Check the prerequisites before continuing:
 
 ```bash
+git --version
 docker --version
 docker compose version
+make --version
+sh -c 'echo POSIX shell: $0'
+openssl version
 ```
 
 For a public deployment you also need a **domain** and a server with ports
@@ -69,7 +79,7 @@ For a public deployment you also need a **domain** and a server with ports
 ## Install
 
 ```bash
-git clone <REPOSITORY_URL>
+git clone https://github.com/sarrazola/openlivery.git
 cd openlivery
 ./scripts/generate-docker-env.sh   # writes .env.docker with random secrets (gitignored)
 make up                            # build, start, run migrations


### PR DESCRIPTION
## What changed

- List Git, GNU Make, a POSIX-compatible shell, and OpenSSL as host prerequisites
- Add commands for checking each required tool
- Clarify that Windows users should run the documented commands from WSL or Git Bash
- Clarify that Python, Node.js, Go, and PostgreSQL run inside containers
- Replace the self-hosting repository placeholder with the public clone URL

## Verification

- Ran `git diff --check`
- Reviewed both English installation guides
- Documentation-only change; no application tests were required

Closes #66