### PR TITLE
ci: grant pull request write access for assignment

### DIFF
--- a/.github/workflows/assign-pull-requests.yml
+++ b/.github/workflows/assign-pull-requests.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   assign:
@@ -34,5 +33,5 @@ jobs:
             gh api --method POST "repos/$GH_REPO/issues/$number/assignees" \
               -f 'assignees[]=sarrazola' \
               -f 'assignees[]=juanpabloortizo' \
-              --silent
+              --jq '"PR #\(.number): \([.assignees[].login] | join(", "))"'
           done <<< "$numbers"


### PR DESCRIPTION
The assignment workflow received HTTP 403 when using issue-write and pull-request-read access. Grant pull-request-write access for PR assignee updates and remove the unnecessary issue permission. Print the returned assignees so each update is visible in the run log.

The workflow still operates only on metadata and never checks out contributor code. Validation will include a manual run against the existing open PRs.
