### PR TITLE
fix(auth): enforce one agency per installation

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -17,10 +17,6 @@ FRONTEND_URL=http://localhost:3000
 # Optional configuration.
 ACCESS_TOKEN_MINUTES=10080
 WHATSAPP_LOG_LEVEL=silent
-# The instance is single-agency by default: the first registration creates the
-# owner agency and closes public sign-up. Set to true only when one deployment
-# must host many agencies.
-# ALLOW_MULTI_AGENCY=false
 
 # Session cookie flags. Behind an HTTPS reverse proxy set COOKIE_SECURE=true.
 COOKIE_SECURE=false

--- a/.env.example
+++ b/.env.example
@@ -14,10 +14,6 @@ FRONTEND_URL=http://localhost:3000
 COOKIE_SECURE=false
 COOKIE_SAMESITE=lax
 
-# The instance is single-agency by default: the first registration creates the
-# owner agency and closes public sign-up. Set to true only when one deployment
-# must host many agencies.
-# ALLOW_MULTI_AGENCY=false
 
 # Public backend URL used by Next.js
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ repo already uses in `apps/web`.
 
 ## Project
 
-OpenLivery is a multi-tenant platform where agencies create and manage AI agents for their clients, with a chat playground, a client portal, and WhatsApp integration. Three services + PostgreSQL:
+One OpenLivery installation serves one agency, which creates and manages AI agents for multiple clients, with a chat playground, client portals, and messaging integrations. First-run setup creates the agency and its owner, then public registration closes permanently. Do not add a setting, endpoint, or UI flow for registering additional agencies. Three services + PostgreSQL:
 
 - `apps/api/` — FastAPI (Python 3.12) + SQLAlchemy + Alembic
 - `apps/web/` — Next.js 16 (App Router) + React 19 + TypeScript + Tailwind
@@ -65,7 +65,7 @@ pytest tests/test_flows.py::test_register_login_logout_and_me -v   # single test
 
 ### Data model (apps/api/app/models.py)
 
-Everything is agency-scoped: `Agency → Users, Clients, AIConnections`; `Client → Agents, WhatsAppChannel, Conversations`; `Agent → Conversations, KnowledgeDocuments`; `Conversation → Messages`. Every router query filters by the authenticated user's `agency_id` — preserve this in any new endpoint; it's the tenant-isolation boundary.
+Everything is agency-scoped: `Agency → Users, Clients, AIConnections`; `Client → Agents, WhatsAppChannel, Conversations`; `Agent → Conversations, KnowledgeDocuments`; `Conversation → Messages`. Every router query filters by the authenticated user's `agency_id`. Preserve this ownership boundary in every new endpoint, including for existing data created by older releases.
 
 ### Backend layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Upgrading: this release adds database migrations (applied automatically by the
 Docker stack; run `alembic upgrade head` on local setups).
 
 ### Changed
+- **One agency per installation.** First-run setup creates the agency and owner,
+  then public registration closes. The former `ALLOW_MULTI_AGENCY` setting is
+  removed and has no effect, even when left in an existing environment file.
+  Existing agencies, users, and client data remain accessible after upgrading.
+  Simultaneous setup requests are serialized so only one can create an agency.
+  The login page requires a successful setup-status check and offers a retry
+  when that check fails. An agency can still manage multiple client workspaces.
 - **The timezone belongs to the client, not the agent.** `clients.timezone`
   replaces `agents.timezone`: it is set when the client is created (the
   browser's zone by default) or on its Details, and every agent of the client

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@
 
 ---
 
-OpenLivery is a multi-tenant workspace where an agency creates AI agents for its
+One OpenLivery installation serves one agency. The agency creates AI agents for its
 clients, gives each client a branded portal, and talks to end users over
 WhatsApp or an embeddable web chat widget. Bring your own OpenAI / Anthropic
 keys and self-host the whole thing with one command.
+
+First-run setup creates your agency and owner account, then public registration
+closes. Add as many client workspaces as your agency needs inside that installation.
 
 ## Documentation
 

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -23,10 +23,6 @@ class Settings(BaseSettings):
     # Rate limiting on public/unauthenticated endpoints (per client IP). Disable
     # only for tests or when a proxy in front already enforces limits.
     rate_limit_enabled: bool = True
-    # A self-hosted instance is single-agency by default: the first registration
-    # creates the owner agency and closes public sign-up (like n8n's owner
-    # setup). Enable only when one deployment must host many agencies.
-    allow_multi_agency: bool = False
     # SSRF guard for agent HTTP tools: URLs resolving to private/loopback
     # addresses are rejected. Enable only on self-hosted deployments that need
     # tools to reach internal services.

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
 from ..config import get_settings
@@ -29,8 +29,6 @@ def _set_session_cookie(response: Response, user: User) -> None:
 
 
 def _registration_open(db: Session) -> bool:
-    if get_settings().allow_multi_agency:
-        return True
     return db.scalar(select(Agency.id).limit(1)) is None
 
 
@@ -41,7 +39,7 @@ def auth_status(db: Session = Depends(get_db)):
     has_agency = db.scalar(select(Agency.id).limit(1)) is not None
     return {
         "needs_setup": not has_agency,
-        "registration_open": get_settings().allow_multi_agency or not has_agency,
+        "registration_open": not has_agency,
     }
 
 
@@ -52,6 +50,10 @@ def auth_status(db: Session = Depends(get_db)):
     dependencies=[Depends(login_rate_limit)],
 )
 def register(payload: RegisterRequest, response: Response, db: Session = Depends(get_db)):
+    # There is no owner row to lock on first run. Serialize setup attempts on
+    # the table, then check again after any earlier attempt commits or rolls
+    # back. Ordinary reads remain available and the lock ends with the transaction.
+    db.execute(text("LOCK TABLE agencies IN EXCLUSIVE MODE"))
     if not _registration_open(db):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -83,3 +83,26 @@ def customer_conversation(client: TestClient, agent_id: str) -> dict:
         db.commit()
     created["channel"] = "widget"
     return created
+
+
+def login_legacy_owner(client: TestClient) -> dict:
+    """Preserve access isolation for data created by older releases.
+
+    Seed the existing owner directly; current setup must never create another
+    agency. Login still needs to work for every existing owner after an upgrade.
+    """
+    from app.models import Agency, User
+    from app.security import hash_password
+
+    credentials = {"email": "legacy-owner@example.com", "password": "legacy-owner-password"}
+    with TestingSession() as db:
+        db.add(User(
+            agency=Agency(name="Legacy agency", slug="legacy-agency"),
+            name="Legacy owner",
+            email=credentials["email"],
+            password_hash=hash_password(credentials["password"]),
+        ))
+        db.commit()
+    response = client.post("/api/auth/login", json=credentials)
+    assert response.status_code == 200, response.text
+    return response.json()

--- a/apps/api/tests/test_flows.py
+++ b/apps/api/tests/test_flows.py
@@ -116,25 +116,6 @@ def test_single_agency_instance_closes_registration(client: TestClient):
     assert client.post("/api/auth/login", json={"email": "laura@norte.com", "password": "very-secure-key"}).status_code == 200
 
 
-def test_multi_agency_flag_keeps_registration_open(client: TestClient, monkeypatch):
-    monkeypatch.setattr(get_settings(), "allow_multi_agency", True)
-
-    first = client.post(
-        "/api/auth/register",
-        json={"agency_name": "North Studio", "name": "Laura", "email": "laura@norte.com", "password": "very-secure-key"},
-    )
-    assert first.status_code == 201
-
-    status = client.get("/api/auth/status").json()
-    assert status == {"needs_setup": False, "registration_open": True}
-
-    second = client.post(
-        "/api/auth/register",
-        json={"agency_name": "South Studio", "name": "Mario", "email": "mario@sur.com", "password": "very-secure-key"},
-    )
-    assert second.status_code == 201
-
-
 def test_provider_key_is_stored_masked(authenticated_client: TestClient):
     saved = authenticated_client.put("/api/providers/openai", json={"api_key": "sk-super-secret-key"})
     assert saved.status_code == 200

--- a/apps/api/tests/test_registration.py
+++ b/apps/api/tests/test_registration.py
@@ -1,0 +1,99 @@
+"""First-run setup is exclusive, retryable, and safe for existing data."""
+
+from concurrent.futures import ThreadPoolExecutor
+from time import monotonic, sleep
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select, text
+
+from app.config import Settings
+from app.main import app
+from app.models import Agency, User
+from app.routers import auth
+from conftest import TestingSession, login_legacy_owner, test_engine
+
+
+def owner(index):
+    return {
+        "agency_name": f"Studio {index}", "name": f"Owner {index}",
+        "email": f"owner{index}@example.com", "password": "safe-test-password",
+    }
+
+
+def test_removed_registration_setting_cannot_reopen_setup(client, monkeypatch):
+    monkeypatch.setenv("ALLOW_MULTI_AGENCY", "true")
+    settings = Settings(_env_file=None)
+    monkeypatch.setattr(auth, "get_settings", lambda: settings)
+    assert client.post("/api/auth/register", json=owner(1)).status_code == 201
+    assert client.get("/api/auth/status").json() == {"needs_setup": False, "registration_open": False}
+    assert client.post("/api/auth/register", json=owner(2)).status_code == 403
+
+
+def test_simultaneous_first_registrations_create_exactly_one_owner(client):
+    def register(index):
+        with TestClient(app) as requester:
+            return requester.post("/api/auth/register", json=owner(index)).status_code
+
+    # Hold writes while both requests reach the database. Reads remain allowed,
+    # so a check-then-insert implementation would let both see an empty table.
+    # Observe the actual database waiters rather than relying on request timing.
+    with test_engine.connect() as blocker, ThreadPoolExecutor(max_workers=2) as executor:
+        blocker.execute(text("LOCK TABLE agencies IN EXCLUSIVE MODE"))
+        attempts = [executor.submit(register, index) for index in (1, 2)]
+        try:
+            deadline = monotonic() + 10
+            while monotonic() < deadline:
+                waiters = blocker.scalar(text("""
+                    SELECT count(*) FROM pg_locks
+                    WHERE database = (SELECT oid FROM pg_database WHERE datname = current_database())
+                      AND relation = 'agencies'::regclass AND NOT granted
+                """))
+                if waiters == 2:
+                    break
+                sleep(0.01)
+            else:
+                pytest.fail("Both setup requests must reach the database before releasing writes")
+        finally:
+            blocker.rollback()
+        assert sorted(attempt.result(timeout=10) for attempt in attempts) == [201, 403]
+
+    with TestingSession() as db:
+        assert db.scalar(select(func.count()).select_from(Agency)) == 1
+        assert db.scalar(select(func.count()).select_from(User)) == 1
+
+
+def test_failed_setup_releases_lock_and_can_be_retried(client, monkeypatch):
+    def fail_hash(_password):
+        raise RuntimeError("Simulated setup failure")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(auth, "hash_password", fail_hash)
+        with pytest.raises(RuntimeError, match="Simulated setup failure"):
+            client.post("/api/auth/register", json=owner(1))
+    assert client.get("/api/auth/status").json() == {"needs_setup": True, "registration_open": True}
+    assert client.post("/api/auth/register", json=owner(1)).status_code == 201
+
+
+def test_existing_owners_keep_login_and_data_after_registration_closes(client):
+    assert client.post("/api/auth/register", json=owner(1)).status_code == 201
+    original_client = client.post("/api/clients", json={"name": "Original client"}).json()
+    legacy = login_legacy_owner(client)
+    assert client.get("/api/auth/me").json()["id"] == legacy["id"]
+    assert client.get(f"/api/clients/{original_client['id']}").status_code == 404
+    assert client.post("/api/auth/register", json=owner(3)).status_code == 403
+    assert client.get("/api/auth/status").json()["registration_open"] is False
+    assert client.post("/api/auth/login", json=owner(1)).status_code == 200
+    assert client.get(f"/api/clients/{original_client['id']}").status_code == 200
+    with TestingSession() as db:
+        assert db.scalar(select(func.count()).select_from(Agency)) == 2
+
+
+def test_one_agency_can_create_multiple_clients(authenticated_client):
+    first = authenticated_client.post("/api/clients", json={"name": "First client"})
+    second = authenticated_client.post("/api/clients", json={"name": "Second client"})
+    assert (first.status_code, second.status_code) == (201, 201)
+    assert first.json()["id"] != second.json()["id"]
+    assert authenticated_client.get("/api/auth/status").json()["registration_open"] is False
+    with TestingSession() as db:
+        assert db.scalar(select(func.count()).select_from(Agency)) == 1

--- a/apps/api/tests/test_social_connections.py
+++ b/apps/api/tests/test_social_connections.py
@@ -15,7 +15,7 @@ from app.security import decrypt_secret
 from app.services import social_connections as service
 from app.services import social_graph as graph
 from app.services.social_graph import subscribe as subscribe_with_provider, verify_account as verify_provider_account
-from conftest import TestingSession
+from conftest import TestingSession, login_legacy_owner
 
 
 @pytest.fixture(autouse=True)
@@ -99,8 +99,7 @@ def test_another_agency_cannot_read_or_change_channel(authenticated_client, monk
     client = authenticated_client
     customer, agent = resources(client)
     assert manual(client, customer, agent).status_code == 200
-    monkeypatch.setattr(get_settings(), "allow_multi_agency", True)
-    assert client.post("/api/auth/register", json={"agency_name": "Other", "name": "Eve", "email": "eve@test.example", "password": "long-enough-password"}).status_code == 201
+    login_legacy_owner(client)
     assert client.get(f"/api/social/instagram/channels/{customer['id']}").status_code == 404
     assert manual(client, customer, agent).status_code == 404
 

--- a/apps/api/tests/test_social_history.py
+++ b/apps/api/tests/test_social_history.py
@@ -5,11 +5,10 @@ from unittest.mock import AsyncMock
 from fastapi import HTTPException
 from sqlalchemy import select
 
-from app.config import get_settings
 from app.models import SocialChannel, SocialHistoryImport, SocialWebhookEvent, now_utc
 from app.services import social_graph as graph
 from app.services import social_history as history
-from conftest import TestingSession
+from conftest import TestingSession, login_legacy_owner
 
 
 def setup(client, monkeypatch):
@@ -32,8 +31,7 @@ def test_history_is_authenticated_and_repeated_requests_reuse_active_job(authent
     assert first.json()["max_conversations"] == 20
     assert first.json()["limited"] is True
     assert client.post(endpoint).json()["id"] == first.json()["id"]
-    monkeypatch.setattr(get_settings(), "allow_multi_agency", True)
-    assert client.post("/api/auth/register", json={"agency_name": "Other", "name": "Eve", "email": "eve@test.example", "password": "long-enough-password"}).status_code == 201
+    login_legacy_owner(client)
     assert client.get(endpoint).status_code == 404
     assert client.post(endpoint).status_code == 404
 

--- a/apps/api/tests/test_social_runtime.py
+++ b/apps/api/tests/test_social_runtime.py
@@ -12,14 +12,13 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy import func, select
 
-from app.config import get_settings
 from app.models import Agent, Contact, ContactIdentity, Conversation, Message, MessageAttachment, ProviderCredential, SocialChannel, SocialOutbox, SocialWebhookEvent, Team, now_utc
 from app.security import encrypt_secret
 from app.services import escalation, notifications, social_connections, social_delivery, social_graph, social_inbound, social_policy, social_worker, whatsapp_inbound
 from app.services.ai import Completion
 from app.services.contacts import merge_contacts, resolve_contact
 from app.services.conversation_state import set_status
-from conftest import TestingSession
+from conftest import TestingSession, login_legacy_owner
 
 
 SECRET = "runtime-test-app-secret"
@@ -398,9 +397,7 @@ def test_other_agency_cannot_read_or_reply_to_social_conversation(authenticated_
         conversation.mode = "human"
         db.commit()
         conversation_id = conversation.id
-    monkeypatch.setattr(get_settings(), "allow_multi_agency", True)
-    result = authenticated_client.post("/api/auth/register", json={"agency_name": "Other", "name": "Other operator", "email": "other@runtime.example", "password": "another-long-password"})
-    assert result.status_code == 201, result.text
+    login_legacy_owner(authenticated_client)
     assert authenticated_client.get(f"/api/conversations/{conversation_id}").status_code == 404
     assert authenticated_client.post(f"/api/conversations/{conversation_id}/reply", json={"content": "Unauthorized"}).status_code == 404
     social_graph.send_text.assert_not_awaited()

--- a/apps/api/tests/test_whatsapp_cloud.py
+++ b/apps/api/tests/test_whatsapp_cloud.py
@@ -8,7 +8,8 @@ from unittest.mock import AsyncMock
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from app.config import get_settings
+from conftest import login_legacy_owner
+
 from app.routers import whatsapp_cloud as whatsapp_cloud_router
 from app.routers import whatsapp_cloud_webhook as webhook_router
 from app.services import ai as ai_service
@@ -111,14 +112,8 @@ def test_configure_channel_hides_secrets(authenticated_client: TestClient, monke
     assert resaved["phone_number_id"] == "222"
     assert resaved["webhook_verify_token"] == channel["webhook_verify_token"]
 
-    # Another agency cannot see the channel. Registration closes after the
-    # first agency, so allow a second one just for this check.
-    monkeypatch.setattr(get_settings(), "allow_multi_agency", True)
-    other = client.post(
-        "/api/auth/register",
-        json={"agency_name": "Other", "name": "Eve", "email": "eve@other.com", "password": "another-password"},
-    )
-    assert other.status_code == 201
+    # Data belonging to an owner from an older installation stays isolated.
+    login_legacy_owner(client)
     assert client.get(f"/api/whatsapp-cloud/channels/{customer['id']}").status_code == 404
 
 

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -13,26 +13,26 @@ type AuthStatus = { needs_setup: boolean; registration_open: boolean };
 export default function LoginPage() {
   const t = useT();
   const router = useRouter();
-  const [mode, setMode] = useState<"login" | "register">("login");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
+  const [statusFailed, setStatusFailed] = useState(false);
+  const [statusAttempt, setStatusAttempt] = useState(0);
+  const mode = authStatus?.needs_setup ? "register" : "login";
 
   useEffect(() => {
+    let active = true;
     api<AuthStatus>("/auth/status")
       .then((status) => {
-        setAuthStatus(status);
-        if (status.needs_setup) setMode("register");
+        if (active) setAuthStatus(status);
       })
-      .catch(() => setAuthStatus({ needs_setup: false, registration_open: true }));
-  }, []);
-
-  // First run (no agency yet) goes straight to setup; afterwards the register
-  // tab only exists on multi-agency instances.
-  const showTabs = Boolean(authStatus && !authStatus.needs_setup && authStatus.registration_open);
+      .catch(() => { if (active) setStatusFailed(true); });
+    return () => { active = false; };
+  }, [statusAttempt]);
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (!authStatus || busy) return;
     setBusy(true);
     setError("");
     const data = Object.fromEntries(new FormData(event.currentTarget));
@@ -73,11 +73,14 @@ export default function LoginPage() {
             <span className="access-card-label"><ShieldCheck size={15} /> {t("auth.cardLabel")}</span>
             <h2>{mode === "register" ? t("auth.cardTitleRegister") : t("auth.cardTitleLogin")}</h2>
             <p>{mode === "register" ? t("auth.cardSubtitleRegister") : t("auth.cardSubtitleLogin")}</p>
-            {showTabs && <div className="auth-tabs">
-              <button type="button" className={mode === "login" ? "active" : ""} onClick={() => { setMode("login"); setError(""); }}>{t("auth.tabLogin")}</button>
-              <button type="button" className={mode === "register" ? "active" : ""} onClick={() => { setMode("register"); setError(""); }}>{t("auth.tabRegister2")}</button>
-            </div>}
-            <form onSubmit={submit} className="access-form">
+            {!authStatus && (statusFailed ? <>
+              <Alert>{t("auth.statusError")}</Alert>
+              <button className="button primary full" type="button" onClick={() => {
+                setStatusFailed(false);
+                setStatusAttempt((attempt) => attempt + 1);
+              }}>{t("auth.retryStatus")}</button>
+            </> : <p role="status"><LoaderCircle className="spin" size={17} /> {t("common.loading")}</p>)}
+            {authStatus && <form onSubmit={submit} className="access-form">
               {mode === "register" && <>
                 <label>{t("auth.agencyName")}<input name="agency_name" required minLength={2} placeholder={t("auth.agencyNamePlaceholder")} /></label>
                 <label>{t("auth.yourName")}<input name="name" required minLength={2} placeholder={t("auth.yourNamePlaceholder")} /></label>
@@ -86,7 +89,7 @@ export default function LoginPage() {
               <label>{t("auth.password")}<PasswordInput name="password" required minLength={8} placeholder={t("auth.passwordPlaceholder")} /></label>
               {error && <Alert>{error}</Alert>}
               <button className="button primary full" disabled={busy}>{busy && <LoaderCircle className="spin" size={17} />}{mode === "register" ? t("auth.submitRegister") : t("auth.submitLogin")}</button>
-            </form>
+            </form>}
             <p className="access-security"><ShieldCheck size={14} /> {t("auth.securityNote")}</p>
           </div>
         </section>

--- a/apps/web/lib/i18n/dicts/core.ts
+++ b/apps/web/lib/i18n/dicts/core.ts
@@ -88,6 +88,8 @@ const en = {
     themeDark: "Dark",
   },
   auth: {
+    statusError: "Could not check whether this installation is ready. Try again to continue.",
+    retryStatus: "Try again",
     signInTitle: "Sign in to OpenLivery",
     signInSubtitle: "Manage your agency's AI agents.",
     registerTitle: "Create your agency",
@@ -227,6 +229,8 @@ const es: typeof en = {
     themeDark: "Oscuro",
   },
   auth: {
+    statusError: "No se pudo comprobar si esta instalación está lista. Inténtalo de nuevo para continuar.",
+    retryStatus: "Intentar de nuevo",
     signInTitle: "Entra a OpenLivery",
     signInSubtitle: "Gestiona los agentes de IA de tu agencia.",
     registerTitle: "Crea tu agencia",

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Everything you need to build, brand and operate AI agents for your clients.
 
 **Concepts**
 
-- [Architecture](en/architecture.md) — The three services, the data model and how tenant isolation works.
+- [Architecture](en/architecture.md) — The three services, the data model and ownership checks.
 
 **Agents**
 
@@ -55,7 +55,7 @@ Todo lo que necesitas para construir, marcar y operar agentes de IA para tus cli
 
 **Conceptos**
 
-- [Arquitectura](es/architecture.md) — Los tres servicios, el modelo de datos y cómo funciona el aislamiento por tenant.
+- [Arquitectura](es/architecture.md) — Los tres servicios, el modelo de datos y las comprobaciones de propiedad.
 
 **Agentes**
 

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -2,7 +2,7 @@
 
 > Leer en español: [architecture.md](../es/architecture.md)
 
-OpenLivery is a multi-tenant platform: three application services plus PostgreSQL, served through a single-origin gateway. This page explains how the pieces fit together, how the data is shaped, and how tenants stay isolated from one another.
+One OpenLivery installation serves one agency with multiple client workspaces: three application services plus PostgreSQL, served through a single-origin gateway. First-run setup creates the agency and its owner, then public registration closes. This page explains the services, data model, and ownership checks.
 
 ## The services
 
@@ -50,9 +50,9 @@ Agency
 
 A `Conversation` records its `channel` (playground, widget or WhatsApp) and a `mode` (`ai` or `human`); switching to `human` pauses the AI so an operator can answer from the inbox. Messages store their role, content and any knowledge `sources` used. See [Agents](agents.md) for how an agent's instructions, brief and knowledge compose into the prompt.
 
-## Tenant isolation
+## Data ownership
 
-The agency is the tenant boundary. `Agency`, `User`, `Client`, `Agent`, `WhatsAppChannel`, `Conversation` and other tables all carry an indexed `agency_id`, and every authenticated router query filters by the caller's `agency_id`. Deleting an agency cascades to everything it owns. Any new endpoint must preserve this filter.
+The agency owns its users and clients; agents, channels, and conversations belong to individual clients. Agency-owned records reference the agency through `agency_id`, and authenticated router queries check that ownership. Portal access is additionally restricted to the current client. Preserve these checks in every new endpoint, including for data created by older releases. They are not a public registration mechanism.
 
 ## Encryption at rest
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -36,6 +36,18 @@ For a non-Docker local setup, the same variables go in a `.env` at the repo root
 
 `ENCRYPTION_KEY` must **never** change once secrets have been stored. It derives the key that decrypts every saved AI API key and WhatsApp session. If you rotate or lose it, those secrets become unrecoverable — you will have to re-enter API keys and re-link WhatsApp numbers. Treat it as permanent for the lifetime of your database.
 
+## Agency setup
+
+Each installation serves one agency with multiple client workspaces. On an empty
+installation, the login page offers first-run setup for the agency and its owner.
+Once setup succeeds, the page offers sign-in only and the API rejects further
+agency registrations. Concurrent setup requests cannot create additional agencies.
+
+To serve more businesses, add clients within your agency. There is no setting to
+reopen agency registration. Upgrading preserves existing users and data; the
+removed `ALLOW_MULTI_AGENCY` environment variable has no effect and can be deleted
+from older configuration files.
+
 ## Host ports
 
 Compose binds each service to a host port, all overridable. Pass them inline to `make up`:

--- a/docs/en/contributing.md
+++ b/docs/en/contributing.md
@@ -4,6 +4,13 @@
 
 Docker is the fastest way to run OpenLivery, but for day-to-day development you usually want each service running on the host with hot reload. This guide covers running the backend, frontend and WhatsApp bridge locally, the test suites, migrations and the project conventions.
 
+## Installation scope
+
+Each installation serves one agency with multiple client workspaces. First-run
+setup creates that agency and its owner, then public registration closes. Do not
+add configuration, API routes, or UI flows for registering additional agencies.
+Keep ownership checks and existing data intact when changing setup or login.
+
 ## Prerequisites
 
 Clone the repository and enable the pre-commit guard once per clone:

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -42,6 +42,10 @@ Prefer not to build locally? `make pull` runs the prebuilt images published to G
 4. Add knowledge (context, Q&A pairs, PDFs) and optionally enable image or audio understanding. See [Knowledge base](knowledge-base.md).
 5. Open the **Playground** to chat with the agent, then connect a [WhatsApp](whatsapp.md) number or embed the [web widget](web-widget.md).
 
+First-run setup is available only until the agency is created. Afterwards, sign
+in to the existing agency and add client workspaces there. See
+[Agency setup](configuration.md#agency-setup).
+
 ## Useful commands
 
 | Command | What it does |

--- a/docs/es/architecture.md
+++ b/docs/es/architecture.md
@@ -2,7 +2,7 @@
 
 > Read in English: [architecture.md](../en/architecture.md)
 
-OpenLivery es una plataforma multi-tenant: tres servicios de aplicación más PostgreSQL, servidos a través de una puerta de enlace de origen único. Esta página explica cómo encajan las piezas, cómo se estructuran los datos y cómo se mantiene aislado cada tenant.
+Cada instalación de OpenLivery sirve a una agencia con múltiples espacios de clientes: tres servicios de aplicación más PostgreSQL, servidos a través de una puerta de enlace de origen único. La configuración inicial crea la agencia y su propietario; después se cierra el registro público. Esta página explica los servicios, el modelo de datos y los controles de acceso.
 
 ## Los servicios
 
@@ -50,9 +50,9 @@ Agency
 
 Una `Conversation` registra su `channel` (playground, widget o WhatsApp) y un `mode` (`ai` o `human`); cambiar a `human` pausa la IA para que un operador pueda responder desde el inbox. Los mensajes guardan su rol, contenido y las `sources` de conocimiento utilizadas. Consulta [Agentes](agents.md) para ver cómo las instrucciones, el brief y el conocimiento de un agente componen el prompt.
 
-## Aislamiento de tenants
+## Propiedad de los datos
 
-La agencia es la frontera del tenant. Las tablas `Agency`, `User`, `Client`, `Agent`, `WhatsAppChannel`, `Conversation` y otras llevan un `agency_id` indexado, y toda consulta autenticada de los routers filtra por el `agency_id` de quien llama. Eliminar una agencia propaga en cascada a todo lo que le pertenece. Cualquier endpoint nuevo debe preservar este filtro.
+La agencia es propietaria de sus usuarios y clientes; los agentes, canales y conversaciones pertenecen a cada cliente. Los registros de la agencia la referencian mediante `agency_id`, y las consultas autenticadas comprueban esa propiedad. El portal limita además el acceso al cliente actual. Conserva estos controles en cada endpoint nuevo, también para datos creados por versiones anteriores. Estos controles no permiten registrar agencias adicionales.
 
 ## Cifrado en reposo
 

--- a/docs/es/configuration.md
+++ b/docs/es/configuration.md
@@ -36,6 +36,18 @@ Para una instalación local sin Docker, las mismas variables van en un `.env` en
 
 `ENCRYPTION_KEY` **nunca** debe cambiar una vez que se han almacenado secretos. Deriva la clave que descifra cada clave de API de IA guardada y cada sesión de WhatsApp. Si la rotas o la pierdes, esos secretos quedan irrecuperables: tendrás que volver a introducir las claves de API y a vincular los números de WhatsApp. Trátala como permanente durante toda la vida de tu base de datos.
 
+## Configuración de la agencia
+
+Cada instalación sirve a una agencia con múltiples espacios de clientes. En una
+instalación vacía, la pantalla de acceso permite crear la agencia y su propietario.
+Después solo permite iniciar sesión y la API rechaza registros de agencias
+adicionales, incluso si dos solicitudes intentan completar la configuración a la vez.
+
+Para atender más negocios, agrega clientes dentro de tu agencia. No hay un ajuste
+para reabrir el registro. La actualización conserva los usuarios y datos existentes;
+la antigua variable `ALLOW_MULTI_AGENCY` ya no tiene efecto y puede eliminarse de
+los archivos de configuración anteriores.
+
 ## Puertos del host
 
 Compose enlaza cada servicio a un puerto del host, todos sobrescribibles. Pásalos en línea a `make up`:

--- a/docs/es/contributing.md
+++ b/docs/es/contributing.md
@@ -4,6 +4,14 @@
 
 Docker es la forma más rápida de ejecutar OpenLivery, pero para el desarrollo diario normalmente querrás cada servicio corriendo en tu máquina con recarga en caliente. Esta guía cubre cómo ejecutar el backend, el frontend y el puente de WhatsApp localmente, las suites de pruebas, las migraciones y las convenciones del proyecto.
 
+## Alcance de la instalación
+
+Cada instalación sirve a una agencia con múltiples espacios de clientes. La
+configuración inicial crea esa agencia y su propietario; después se cierra el
+registro público. No añadas configuración, rutas de API ni flujos de interfaz
+para registrar agencias adicionales. Conserva las comprobaciones de propiedad
+y los datos existentes al modificar la configuración inicial o el acceso.
+
 ## Requisitos previos
 
 Clona el repositorio y activa el guard de pre-commit una vez por clon:

--- a/docs/es/getting-started.md
+++ b/docs/es/getting-started.md
@@ -42,6 +42,10 @@ API_PORT=8001 WEB_PORT=3001 DB_PORT=5433 make up
 4. Añade conocimiento (contexto, pares de preguntas y respuestas, PDFs) y opcionalmente activa la comprensión de imágenes o audio. Consulta [Base de conocimiento](knowledge-base.md).
 5. Abre el **Playground** para chatear con el agente, y luego conecta un número de [WhatsApp](whatsapp.md) o integra el [widget web](web-widget.md).
 
+La configuración inicial solo está disponible hasta que se crea la agencia.
+Después, inicia sesión en esa agencia y agrega los espacios de tus clientes allí.
+Consulta [Configuración de la agencia](configuration.md#configuración-de-la-agencia).
+
 ## Comandos útiles
 
 | Comando | Qué hace |


### PR DESCRIPTION
First-run setup now creates one agency and owner per installation, then permanently closes public registration. The former `ALLOW_MULTI_AGENCY` setting has been removed; concurrent setup requests are serialized in PostgreSQL so two first requests cannot create two agencies.

The login page shows setup only for an empty installation. It waits for a successful status check and offers a retry if that check fails. Existing users, agency-owned data, and multiple client workspaces are preserved. The configuration, first-run, architecture, and contributor guides describe the resulting behavior and upgrade path.

Validation completed: the complete API suite (330 tests passed, including five new setup regressions), frontend ESLint and production build, WhatsApp bridge `go test ./...` and `go vet ./...`. Browser checks covered a failed status request, retry into setup, and sign-in only after setup using controlled API responses.

This supersedes the former configuration documentation request in #67 and #70.
